### PR TITLE
Fixed image url and log errors during import

### DIFF
--- a/hyrax/lib/importers/hyrax_importer.rb
+++ b/hyrax/lib/importers/hyrax_importer.rb
@@ -87,15 +87,11 @@ module Importers
     private
 
       def add_work
-        begin
-          @object = find_work if @object.blank?
-          if @object
-            update_work
-          else
-            create_work
-          end
-        rescue
-          puts "========= Error creating work #{@work_id} ================"
+        @object = find_work if @object.blank?
+        if @object
+          update_work
+        else
+          create_work
         end
       end
 

--- a/hyrax/lib/importers/image_importer.rb
+++ b/hyrax/lib/importers/image_importer.rb
@@ -21,7 +21,7 @@ module Importers
       def get_collection(col_url)
         collections = {
           'http://imeji.nims.go.jp/imeji/collection/sdZWq3eqN1ivoU60/' => {
-            id: '12579s24j',
+            id: '2d0752c0-fc37-4773-b764-b79ba0fc3139',
             title: ['Fiber fuse damage'],
             description: ['Top part of damage train left after a sudden shutdown of laser power supply.'],
             related_url: ['http://imeji.nims.go.jp/imeji/collection/sdZWq3eqN1ivoU60/'],
@@ -29,7 +29,7 @@ module Importers
             visibility: 'open'
           },
           'http://imeji.nims.go.jp/imeji/collection/8' => {
-            id: '2227mp645',
+            id: '0f252c92-c493-4a69-88c1-6f869ff87d8e',
             title: ['Fiber Fuse Movies'],
             description: ['It looks like a tiny comet, a light-induced breakdown of a silica glass optical fiber. In situ image and fused fibers are presented. See also a YouTube video http://www.youtube.com/watch?v=BVmIgaafERk'],
             related_url: ['http://imeji.nims.go.jp/imeji/collection/8'],
@@ -37,7 +37,7 @@ module Importers
             visibility: 'open'
           },
           'http://imeji.nims.go.jp/imeji/collection/PK_GJp0wrrycetcj' => {
-            id: 'sf268509m',
+            id: '77e4e495-6046-4c52-9b2c-a1afb84276c1',
             title: [' Fiber fuse damage 2'],
             description: ['Initial part of damage train left after a fiber fuse initiation.'],
             related_url: ['http://imeji.nims.go.jp/imeji/collection/PK_GJp0wrrycetcj'],
@@ -45,7 +45,7 @@ module Importers
             visibility: 'open'
           },
           'http://imeji.nims.go.jp/imeji/collection/DEIKQkLx77W3Jrlc' => {
-            id: 'hm50tr726',
+            id: '74e1cb36-357d-49a0-9e94-56c9213a2cf6',
             title: ['フラーレンナノウィスカー'],
             description: ['フラーレンナノウィスカーの成長写真'],
             related_url: ['http://imeji.nims.go.jp/imeji/collection/DEIKQkLx77W3Jrlc'],
@@ -53,7 +53,7 @@ module Importers
             visibility: 'open'
           },
           'http://imeji.nims.go.jp/imeji/profile/15' => {
-            id: 'pg15bd88s',
+            id: 'c8265f76-dc6a-44bd-8b63-4c87f0e3b814',
             title: ['Profile information: Optical emission of Methylene Blue'],
               description: ['Optical emission from Methylene Blue in ethanolic solution (excited by a green (532-nm) laser pointer).'],
             related_url: ['http://imeji.nims.go.jp/imeji/profile/15'],
@@ -109,7 +109,7 @@ module Importers
             collection = Importers::CollectionImporter.new(collection_attrs, collection_attrs[:id], 'open')
             collection.create_collection
             col_id = collection.col_id
-            metadata[:member_of_collection_ids] = [collection.col_id]
+            attributes[:member_of_collection_ids] = [collection.col_id]
           end
 
           # Import image

--- a/hyrax/lib/importers/publication_importer.rb
+++ b/hyrax/lib/importers/publication_importer.rb
@@ -6,11 +6,11 @@ module Importers
   class PublicationImporter
     attr_accessor :import_dir, :metadata_file, :debug
 
-    def initialize(import_dir, metadata_file, debug=false, log_file=nil)
+    def initialize(import_dir, metadata_file, debug=false, log_file='import_publication_log.csv')
       @import_dir = import_dir
       @metadata_file = metadata_file
       @debug = debug
-      @log_file = log_file || 'import_dataset.csv'
+      @log_file = log_file
     end
 
     def perform_create
@@ -52,31 +52,59 @@ module Importers
         #     components (= files)
         #     relations
         #     resources
+
+        # get collection attributes
         col_attrs = set_collection_attrs
-        col = Importers::CollectionImporter.new(col_attrs, col_attrs[:id], 'open')
-        col.create_collection
+
+        # create collection
+        unless debug
+          col = Importers::CollectionImporter.new(col_attrs, col_attrs[:id], 'open')
+          col.create_collection
+          col_id = collection.col_id
+        end
+
+        # Open publications xml file
         pub_xml = File.open(metadata_file) { |f| Nokogiri::XML(f) }
+
+        # Each xml file has multiple items
         pub_xml.xpath('/root/item').each do |item|
+          # Set defaults
           work_id = nil
+          attributes = {}
+          files = []
+          files_ignored = []
+          files_missing = []
+          remote_files = []
+          error = nil
+
+          # Get attributes
           attributes = get_properties(item)
-          metadata = get_metadata(item)
-          attributes.merge!(metadata)
-          attributes.merge!({member_of_collection_ids: [col.col_id]})
-          work_id = attributes[:id] unless attributes.fetch(:id, nil).blank?
+          attributes.merge!(get_metadata(item))
+          attributes.merge!({member_of_collection_ids: [col_id]}) unless col_id.blank?
+
+          # Get files
           files_list = get_components(item)
           files = files_list[0]
           files_ignored = files_list[1]
           files_missing = files_list[2]
-          log_progress(metadata_file, work_id, col_attrs[:title], files, files_ignored, files_missing, attributes)
-          puts attributes
-          puts '-'*50
-          puts files
-          puts '~'*50
-          remote_files = []
-          unless debug
+
+          if debug
+            log_progress(metadata_file, work_id, col_id, files, files_ignored, files_missing, attributes)
+            next
+          end
+
+          # Import image
+          begin
+            # Set work id to be same as the id in metadata
+            work_id = attributes[:id] unless attributes.fetch(:id, nil).blank?
             h = Importers::HyraxImporter.new('Publication', attributes, files, remote_files, work_id)
             h.import
+          rescue StandardError => exception
+            error = exception.backtrace
           end
+
+          # log progress
+          log_progress(metadata_file, work_id, col_id, files, files_ignored, files_missing, attributes)
         end
       end
 

--- a/hyrax/lib/importers/publication_importer.rb
+++ b/hyrax/lib/importers/publication_importer.rb
@@ -60,7 +60,7 @@ module Importers
         unless debug
           col = Importers::CollectionImporter.new(col_attrs, col_attrs[:id], 'open')
           col.create_collection
-          col_id = collection.col_id
+          col_id = col.col_id
         end
 
         # Open publications xml file
@@ -531,7 +531,7 @@ module Importers
         csv_file << [
           'metadata file',
           'work id',
-          'collection title',
+          'collection',
           'files to be added',
           'files ignored',
           'files missing',


### PR DESCRIPTION
This PR addresses the following
 - Create csv log file for dataset importer rather than pollute each folder
 - Log errors that are raised when a work is created or updated
 - Collection is not created if in debug
 - Import URL is fixed for images. Only full image is saved
