### PR TITLE
Addressing feedback on metadata form

### DIFF
--- a/hyrax/app/assets/stylesheets/ngdr.scss
+++ b/hyrax/app/assets/stylesheets/ngdr.scss
@@ -86,4 +86,8 @@ form .field-wrapper label[required="required"]::after {
     /* symbol for "collapsed" panels */
     content: "\e080";    /* adjust as needed, taken from bootstrap.css */
 }
+//-------------- edit form css --------------
+.switch-upload-type {
+  display: none;
+}
 //--------------------------------------

--- a/hyrax/app/forms/hyrax/dataset_form.rb
+++ b/hyrax/app/forms/hyrax/dataset_form.rb
@@ -18,13 +18,12 @@ module Hyrax
 
     self.terms += [
       # Adding all fields in order of display in form
-      :title, :alternative_title, :description, :keyword, :language,
-      :publisher, :complex_rights, :subject, :complex_date, :complex_person,
+      :title, :alternative_title, :data_origin, :description, :specimen_set, :keyword,
+      :complex_person, :complex_rights, :complex_date,
       :complex_version, :characterization_methods, :computational_methods,
-      :complex_organization,
-      # :complex_identifier # not using this for now
-      :data_origin, :complex_instrument, :origin_system_provenance,
-      :properties_addressed, :complex_relation, :specimen_set,
+      :complex_identifier,
+      :complex_instrument,
+      :properties_addressed, :complex_relation,
       :complex_specimen_type, :synthesis_and_processing, :custom_property
     ]
 
@@ -36,21 +35,20 @@ module Hyrax
 
     self.required_fields += [
       # # Adding all required fields in order of display in form
-      :title, :data_origin, :specimen_set
+      :title, :data_origin, :specimen_set, :keyword, :complex_rights, :complex_date
     ]
 
     def metadata_tab_terms
       [
-        :title, :alternative_title, :description, :complex_person,
-        :complex_organization, :keyword, :subject, :language, :publisher,
-        :complex_date, :complex_rights, :complex_version, :complex_relation
+        :title, :alternative_title, :data_origin, :description, :specimen_set, :keyword,
+        :complex_person, :complex_rights, :complex_date, :complex_identifier, :complex_version, :complex_relation
       ]
     end
 
     def method_tab_terms
       [
-        :characterization_methods, :computational_methods, :data_origin,
-        :origin_system_provenance, :properties_addressed, :specimen_set,
+        :characterization_methods, :computational_methods,
+        :properties_addressed,
         :synthesis_and_processing, :custom_property
       ]
     end

--- a/hyrax/app/forms/hyrax/publication_form.rb
+++ b/hyrax/app/forms/hyrax/publication_form.rb
@@ -18,11 +18,10 @@ module Hyrax
 
     self.terms += [
       # Adding all fields in order of display in form
-      :title, :alternative_title, :description, :keyword, :language,
-      :publisher, :resource_type, :complex_rights, :subject,
-      :complex_date, :complex_identifier, :complex_person, :complex_version,
-      :complex_event, :issue, :source, :place, :complex_source, :table_of_contents,
-      :total_number_of_pages
+      :title, :alternative_title, :complex_person, :description, :keyword,
+      :publisher, :resource_type, :complex_rights,
+      :complex_date, :complex_identifier, :complex_source, :complex_version,
+      :complex_event, :language
     ]
 
     self.required_fields -= [
@@ -33,7 +32,7 @@ module Hyrax
 
     self.required_fields += [
       # # Adding all required fields in order of display in form
-      :title
+      :title, :keyword, :resource_type, :complex_date, :complex_rights
     ]
 
     NESTED_ASSOCIATIONS = [:complex_date, :complex_identifier,

--- a/hyrax/app/indexers/complex_field/custom_property_indexer.rb
+++ b/hyrax/app/indexers/complex_field/custom_property_indexer.rb
@@ -14,12 +14,12 @@ module ComplexField
       solr_doc[Solrizer.solr_name('custom_property', :stored_searchable)] = property
       object.custom_property.each do |c|
         unless (c.label.first.blank? or c.description.first.blank?)
-          # description as custom property label searchable
+          # description as custom property (additional metadata) label searchable
           fld_name = Solrizer.solr_name("custom_property_#{c.label.first.downcase.tr(' ', '_')}", :stored_searchable)
           solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
           solr_doc[fld_name] << c.description.reject(&:blank?)
           solr_doc[fld_name].flatten!
-          # description as custom property label facetable
+          # description as custom property (additional metadata) label facetable
           fld_name = Solrizer.solr_name("custom_property_#{c.label.first.downcase.tr(' ', '_')}", :facetable)
           solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
           solr_doc[fld_name] << c.description.reject(&:blank?)

--- a/hyrax/app/indexers/complex_field/instrument_indexer.rb
+++ b/hyrax/app/indexers/complex_field/instrument_indexer.rb
@@ -107,7 +107,7 @@ module ComplexField
       # solr fields that will be used for a search
       fields = []
       fields << Solrizer.solr_name('instrument_title', :stored_searchable)
-      fields << Solrizer.solr_name('instrument_alternative_title', :stored_searchable)
+      # fields << Solrizer.solr_name('instrument_alternative_title', :stored_searchable)
       fields << Solrizer.solr_name('instrument_description', :stored_searchable)
       fields << Solrizer.solr_name('instrument_manufacturer', :stored_searchable)
       fields << Solrizer.solr_name('instrument_manufacturer_sub_organization', :stored_searchable)

--- a/hyrax/app/inputs/nested_custom_property_input.rb
+++ b/hyrax/app/inputs/nested_custom_property_input.rb
@@ -52,7 +52,7 @@ protected
 
     # --- delete checkbox
     if repeats == true
-      field_label = 'Custom property'
+      field_label = 'Additional metadata'
       out << "  <div class='col-md-3'>"
       out << destroy_widget(attribute_name, index, field_label, parent)
       out << '  </div>'

--- a/hyrax/app/inputs/nested_instrument_input.rb
+++ b/hyrax/app/inputs/nested_instrument_input.rb
@@ -35,7 +35,24 @@ protected
     out << '</div>' # row
 
     # --- alternative_title
-    field = :alternative_title
+    # field = :alternative_title
+    # field_name = name_for(attribute_name, index, field, parent)
+    # field_id = id_for(attribute_name, index, field, parent)
+    # field_value = value.send(field).first
+
+    # out << "<div class='row'>"
+    # out << "  <div class='col-md-3'>"
+    # out << template.label_tag(field_name, field.to_s.humanize, required: required)
+    # out << '  </div>'
+
+    # out << "  <div class='col-md-9'>"
+    # out << @builder.text_field(field_name,
+    #     options.merge(value: field_value, name: field_name, id: field_id, required: required))
+    # out << '  </div>'
+    # out << '</div>' # row
+
+    # --- description
+    field = :description
     field_name = name_for(attribute_name, index, field, parent)
     field_id = id_for(attribute_name, index, field, parent)
     field_value = value.send(field).first
@@ -70,23 +87,6 @@ protected
     # out << "    <span class='controls-add-text'>Add another date</span>"
     # out << "  </button>"
     out << "</div>" # row
-
-    # --- description
-    field = :description
-    field_name = name_for(attribute_name, index, field, parent)
-    field_id = id_for(attribute_name, index, field, parent)
-    field_value = value.send(field).first
-
-    out << "<div class='row'>"
-    out << "  <div class='col-md-3'>"
-    out << template.label_tag(field_name, field.to_s.humanize, required: required)
-    out << '  </div>'
-
-    out << "  <div class='col-md-9'>"
-    out << @builder.text_field(field_name,
-        options.merge(value: field_value, name: field_name, id: field_id, required: required))
-    out << '  </div>'
-    out << '</div>' # row
 
     # --- complex_identifier
     field = :complex_identifier

--- a/hyrax/app/models/concerns/complex_instrument.rb
+++ b/hyrax/app/models/concerns/complex_instrument.rb
@@ -3,13 +3,13 @@ class ComplexInstrument < ActiveTriples::Resource
 
   configure type: ::RDF::Vocab::NimsRdp['Instrument']
 
-  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+#  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
+
+property :description, predicate: ::RDF::Vocab::DC11.description
 
   property :complex_date, predicate: ::RDF::Vocab::NimsRdp["instrument-date"],
             class_name:"ComplexDate"
   accepts_nested_attributes_for :complex_date
-
-  property :description, predicate: ::RDF::Vocab::DC11.description
 
   property :complex_identifier, predicate: ::RDF::Vocab::MODS.identifierGroup,
             class_name:"ComplexIdentifier"

--- a/hyrax/app/models/concerns/complex_instrument.rb
+++ b/hyrax/app/models/concerns/complex_instrument.rb
@@ -5,7 +5,7 @@ class ComplexInstrument < ActiveTriples::Resource
 
 #  property :alternative_title, predicate: ::RDF::Vocab::DC.alternative
 
-property :description, predicate: ::RDF::Vocab::DC11.description
+  property :description, predicate: ::RDF::Vocab::DC11.description
 
   property :complex_date, predicate: ::RDF::Vocab::NimsRdp["instrument-date"],
             class_name:"ComplexDate"

--- a/hyrax/app/renderers/nested_instrument_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_instrument_attribute_renderer.rb
@@ -11,23 +11,23 @@ class NestedInstrumentAttributeRenderer < NestedAttributeRenderer
         val = link_to(ERB::Util.h(v['title'][0]), search_path(v['title'][0]))
         each_html += get_row(label, val)
       end
-      # alternative title
-      unless v.dig('alternative_title').blank?
-        label = 'Alternative title'
-        val = v['alternative_title'][0]
-        each_html += get_row(label, val)
-      end
-      # complex date
-      unless v.dig('complex_date').blank?
-        label = 'Date'
-        renderer_class = NestedDateAttributeRenderer
-        each_html += get_nested_output(label, v['complex_date'], renderer_class, false)
-      end
       # description
       unless v.dig('description').blank?
         label = 'Description'
         val = v['description'][0]
         each_html += get_row(label, val)
+      end
+      # alternative title
+      # unless v.dig('alternative_title').blank?
+      #   label = 'Alternative title'
+      #   val = v['alternative_title'][0]
+      #   each_html += get_row(label, val)
+      # end
+      # complex date
+      unless v.dig('complex_date').blank?
+        label = 'Date'
+        renderer_class = NestedDateAttributeRenderer
+        each_html += get_nested_output(label, v['complex_date'], renderer_class, false)
       end
       # complex identifier
       unless v.dig('complex_identifier').blank?

--- a/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
+++ b/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
@@ -84,12 +84,12 @@
     </div> <!-- Accordion body -->
   </div> <!-- Description accordion -->
 
-  <!-- Experimental method accordion -->
+  <!-- Method accordion -->
   <div class="panel panel-default">
     <!-- Accordion header -->
     <div class="panel-heading" data-toggle="collapse" data-target="#experimentalMethod">
       <h4 class="panel-title">
-        <a class="accordion-toggle">Experimental method</a>
+        <a class="accordion-toggle">Method</a>
       </h4>
     </div> <!-- Accordion header -->
     <!-- Accordion body -->
@@ -127,14 +127,14 @@
           html_dl: true) %>
       </div> <!-- panel body -->
     </div> <!-- Accordion body -->
-  </div> <!-- Experimental method accordion -->
+  </div> <!-- Method accordion -->
 
-  <!-- Instrument accordion -->
+  <!-- Instruments accordion -->
   <div class="panel panel-default">
     <!-- Accordion header -->
     <div class="panel-heading" data-toggle="collapse" data-target="#instrument">
       <h4 class="panel-title">
-        <a class="accordion-toggle">Instrument</a>
+        <a class="accordion-toggle">Instruments</a>
       </h4>
     </div> <!-- Accordion header -->
     <!-- Accordion body -->
@@ -146,14 +146,14 @@
           html_dl: true) %>
       </div> <!-- panel body -->
     </div> <!-- Accordion body -->
-  </div> <!-- Instrument accordion -->
+  </div> <!-- Instruments accordion -->
 
-  <!-- Specimen type accordion -->
+  <!-- Specimen details accordion -->
   <div class="panel panel-default">
     <!-- Accordion header -->
     <div class="panel-heading" data-toggle="collapse" data-target="#specimenType">
       <h4 class="panel-title">
-        <a class="accordion-toggle">Specimen type</a>
+        <a class="accordion-toggle">Specimen details</a>
       </h4>
     </div> <!-- Accordion header -->
     <!-- Accordion body -->
@@ -165,7 +165,7 @@
           html_dl: true) %>
       </div> <!-- panel body -->
     </div> <!-- Accordion body -->
-  </div> <!-- Specimen type accordion -->
+  </div> <!-- Specimen details accordion -->
 
 </div>
 <!-- Accordion wrapper -->

--- a/hyrax/app/views/records/edit_fields/_custom_property.html.erb
+++ b/hyrax/app/views/records/edit_fields/_custom_property.html.erb
@@ -9,6 +9,6 @@
   %>
   <button type="button" class="btn btn-link add">
     <span class="glyphicon glyphicon-plus"></span>
-    <span class="controls-add-text">Add another custom property</span>
+    <span class="controls-add-text">Add another metadata</span>
   </button>
 </div>

--- a/hyrax/config/authorities/characterization_methods.yml
+++ b/hyrax/config/authorities/characterization_methods.yml
@@ -283,3 +283,6 @@ terms:
 - id: viscometry
   term: viscometry/粘度測定
   active: true
+- id: other
+  term: other/その他
+  active: true

--- a/hyrax/config/authorities/computational_methods.yml
+++ b/hyrax/config/authorities/computational_methods.yml
@@ -53,3 +53,7 @@ terms:
 - id: statistical mechanics
   term: statistical mechanics/統計力学
   active: true
+- id: other
+  term: other/その他
+  active: true
+  

--- a/hyrax/config/authorities/resource_types.yml
+++ b/hyrax/config/authorities/resource_types.yml
@@ -5,36 +5,18 @@ terms:
     term: Audio
   - id: Book
     term: Book
-  - id: Capstone Project
-    term: Capstone Project
   - id: Conference Proceeding
     term: Conference Proceeding
-  - id: Dataset
-    term: Dataset
   - id: Dissertation
     term: Dissertation
   - id: Image
     term: Image
-  - id: Journal
-    term: Journal
-  - id: Map or Cartographic Material
-    term: Map or Cartographic Material
-  - id: Masters Thesis
-    term: Masters Thesis
-  - id: Part of Book
-    term: Part of Book
   - id: Poster
     term: Poster
   - id: Presentation
     term: Presentation
-  - id: Project
-    term: Project
   - id: Report
     term: Report
-  - id: Research Paper
-    term: Research Paper
-  - id: Software or Program Code
-    term: Software or Program Code
   - id: Video
     term: Video
   - id: Other

--- a/hyrax/config/locales/dataset.en.yml
+++ b/hyrax/config/locales/dataset.en.yml
@@ -22,7 +22,7 @@ en:
         complex_rights:           "Rights"
         complex_version:          "Version"
         computational_methods:    "Computational methods"
-        custom_property:          "custom property"
+        custom_property:          "Additional metadata"
         data_origin:              "Data origin"
         complex_instrument:       "Instrument"
         material_types:           "Material types "

--- a/hyrax/config/locales/dataset.en.yml
+++ b/hyrax/config/locales/dataset.en.yml
@@ -31,7 +31,7 @@ en:
         part_of:                  "Part of"
         processing_environment:   "Processing environment"
         properties_addressed:     "Properties addressed"
-        specimen_set:             "Specimen set"
+        specimen_set:             "Specimen"
         complex_specimen_type:    "Specimen type"
         complex_structural_features: "Structural features"
         synthesis_and_processing: "Synthesis and processing"

--- a/hyrax/config/locales/en.yml
+++ b/hyrax/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       processing_environment:   "Processing environment"
       properties_addressed:     "Properties addressed"
       purchase_record_item:     "Purchase record item"
-      specimen_set:             "Specimen set"
+      specimen_set:             "Specimen"
       specimen_type:            "Specimen type"
       status:                   "Status"
       status_at_end:            "Status at end"
@@ -54,4 +54,3 @@ en:
       sub_organization:         "Sub organization"
       synthesis_and_processing: "Synthesis and processing"
       total_number_of_pages:    "Number of pages"
-

--- a/hyrax/config/locales/en.yml
+++ b/hyrax/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
       category:                 "Category"
       characterization_methods: "Characterization methods"
       computational_methods:    "Computational methods"
-      custom_property:          "Custom property"
+      custom_property:          "Additional metadata"
       column_number:            "Column number"
       complex_affiliation:      "Affiliation"
       complex_chemical_composition: "Chemical composition"

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -62,7 +62,7 @@ en:
           place_sim: Location
           properties_addressed_sim: Properties addressed
           publisher_sim: Publisher
-          specimen_set_sim: Specimen set
+          specimen_set_sim: Specimen
           subject_sim: Subject
           synthesis_and_processing_sim: Synthesis and processing
         index:
@@ -149,7 +149,7 @@ en:
           properties_addressed_tesim: Properties addressed
           publisher_tesim: Publisher
           rights_statement_tesim: Rights Statement
-          specimen_set_tesim: Specimen set
+          specimen_set_tesim: Specimen
           subject_tesim: Subject
           synthesis_and_processing_tesim: Synthesis and processing
         show:
@@ -210,7 +210,7 @@ en:
           properties_addressed_tesim: Properties processed
           publisher_tesim: Publisher
           rights_statement_tesim: Rights Statement
-          specimen_set_tesim: Specimen set
+          specimen_set_tesim: Specimen
           subject_tesim: Subject
           synthesis_and_processing_tesim: Synthesis and processing
           table_of_contents_tesim: Table of contents

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -45,7 +45,7 @@ en:
           complex_sub_organization_sim: Sub organization
           complex_person_sim: Creator
           computational_methods_sim: Computational methods
-          custom_property_sim: Custom property
+          custom_property_sim: Additional metadata
           data_origin_sim: Data origin
           file_format_sim: Format
           generic_type_sim: Type
@@ -125,7 +125,7 @@ en:
           complex_structural_feature_identifier_ssim: Structural feature identifier
           complex_version_ssim: Version
           computational_methods_tesim: Computational methods
-          custom_property_tesim: Custom property
+          custom_property_tesim: Additional metadata
           data_origin_tesim: Data origin
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
@@ -192,7 +192,7 @@ en:
           complex_specimen_type_ssm: Specimen type
           complex_version_ssm: Version
           creator_tesim: Creator
-          custom_property_ssm: Custom property
+          custom_property_ssm: Additional metadata
           data_origin_tesim: Data origin
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
@@ -232,8 +232,8 @@ en:
         tab:
           files: Files
           metadata: Descriptions
-          method: Experimental method
-          instrument: Instrument
+          method: Method
+          instrument: Instruments
           relationships: Relationships
           share: Sharing
-          specimen: Specimen type
+          specimen: Specimen details

--- a/hyrax/config/locales/publication.en.yml
+++ b/hyrax/config/locales/publication.en.yml
@@ -16,7 +16,7 @@ en:
         complex_person:           "Creator"
         complex_relation:         "Related item"
         complex_rights:           "Rights"
-        complex_source:           "Journal"
+        complex_source:           "Journal, Book, Proceedings, or Database"
         complex_version:          "Version"
         part_of:                  "Part of"
         issue:                    "Issue"

--- a/hyrax/spec/fixtures/complete_dataset.rb
+++ b/hyrax/spec/fixtures/complete_dataset.rb
@@ -41,7 +41,6 @@ dataset_attributes = {
   computational_methods: 'computational methods',
   data_origin: ['informatics and data science'],
   complex_instrument_attributes: [{
-    alternative_title: 'An instrument title',
     complex_date_attributes: [{
       date: ['2018-02-14'],
       description: 'Processed'

--- a/hyrax/spec/fixtures/complete_dataset.rb
+++ b/hyrax/spec/fixtures/complete_dataset.rb
@@ -72,7 +72,7 @@ dataset_attributes = {
     }],
     relationship: 'isSupplementTo'
   }],
-  specimen_set: 'Specimen set',
+  specimen_set: 'Specimen',
   specimen_type_attributes: [{
     chemical_composition: 'chemical composition',
     crystallographic_structure: 'crystallographic structure',

--- a/hyrax/spec/indexers/dataset_indexer_spec.rb
+++ b/hyrax/spec/indexers/dataset_indexer_spec.rb
@@ -896,7 +896,7 @@ RSpec.describe DatasetIndexer do
     end
   end
 
-  describe 'indexes a custom property active triple resource with all the attributes' do
+  describe 'indexes a custom property (additional metadata) active triple resource with all the attributes' do
     before do
       custom_properties = [
         {

--- a/hyrax/spec/models/concerns/complex_instrument_spec.rb
+++ b/hyrax/spec/models/concerns/complex_instrument_spec.rb
@@ -37,14 +37,13 @@ RSpec.describe ComplexInstrument do
     @obj.attributes = {
       complex_instrument_attributes: [
         {
-          alternative_title: 'An instrument title',
-          complex_date_attributes: [{
-            date: ['2018-02-14']
-          }],
           description: 'Instrument description',
           complex_identifier_attributes: [{
             identifier: ['123456'],
             label: ['Local']
+          }],
+          complex_date_attributes: [{
+            date: ['2018-02-14']
           }],
           instrument_function_attributes: [{
             column_number: 1,
@@ -80,10 +79,9 @@ RSpec.describe ComplexInstrument do
       ]
     }
     expect(@obj.complex_instrument.first).to be_kind_of ActiveTriples::Resource
-    expect(@obj.complex_instrument.first.alternative_title).to eq ['An instrument title']
+    expect(@obj.complex_instrument.first.description).to eq ['Instrument description']
     expect(@obj.complex_instrument.first.complex_date.first).to be_kind_of ActiveTriples::Resource
     expect(@obj.complex_instrument.first.complex_date.first.date).to eq ['2018-02-14']
-    expect(@obj.complex_instrument.first.description).to eq ['Instrument description']
     expect(@obj.complex_instrument.first.complex_identifier.first).to be_kind_of ActiveTriples::Resource
     expect(@obj.complex_instrument.first.complex_identifier.first.identifier).to eq ['123456']
     expect(@obj.complex_instrument.first.complex_identifier.first.label).to eq ['Local']

--- a/hyrax/spec/models/concerns/complex_key_value_spec.rb
+++ b/hyrax/spec/models/concerns/complex_key_value_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ComplexKeyValue do
     expect(@obj.custom_property.first.id).to include('#key_value')
   end
 
-  it 'creates a custom property active triple resource with all the attributes' do
+  it 'creates a custom property (additional metadata) active triple resource with all the attributes' do
     @obj = ExampleWork.new
     @obj.attributes = {
       custom_property_attributes: [
@@ -51,7 +51,7 @@ RSpec.describe ComplexKeyValue do
       Object.send(:remove_const, :ExampleWork2)
     end
 
-    it 'rejects a custom property active triple with no label' do
+    it 'rejects a custom property (additional metadata) active triple with no label' do
       @obj = ExampleWork2.new
       @obj.attributes = {
         custom_property_attributes: [
@@ -63,7 +63,7 @@ RSpec.describe ComplexKeyValue do
       expect(@obj.custom_property).to be_empty
     end
 
-    it 'rejects a custom property active triple with no description' do
+    it 'rejects a custom property (additional metadata) active triple with no description' do
       @obj = ExampleWork2.new
       @obj.attributes = {
         custom_property_attributes: [

--- a/hyrax/spec/models/dataset_spec.rb
+++ b/hyrax/spec/models/dataset_spec.rb
@@ -647,8 +647,8 @@ RSpec.describe Dataset do
 
   describe 'specimen_set' do
     it 'has specimen_set' do
-      @obj = build(:dataset, specimen_set: 'Specimen set')
-      expect(@obj.specimen_set).to eq 'Specimen set'
+      @obj = build(:dataset, specimen_set: 'Specimen')
+      expect(@obj.specimen_set).to eq 'Specimen'
     end
   end
 

--- a/hyrax/spec/models/dataset_spec.rb
+++ b/hyrax/spec/models/dataset_spec.rb
@@ -967,7 +967,7 @@ RSpec.describe Dataset do
   end
 
   describe 'custom_property' do
-    it 'creates a custom property active triple resource with all the attributes' do
+    it 'creates a custom property (additional metadata) active triple resource with all the attributes' do
       @obj = build(:dataset,
         custom_property_attributes: [{
           label: 'Full name',
@@ -980,7 +980,7 @@ RSpec.describe Dataset do
       expect(@obj.custom_property.first.description).to eq ['My full name is ...']
     end
 
-    it 'rejects a custom property active triple with no label' do
+    it 'rejects a custom property (additional metadata) active triple with no label' do
       @obj = build(:dataset,
         custom_property_attributes: [{
           description: 'Local date'
@@ -989,7 +989,7 @@ RSpec.describe Dataset do
       expect(@obj.custom_property).to be_empty
     end
 
-    it 'rejects a custom property active triple with no description' do
+    it 'rejects a custom property (additional metadata) active triple with no description' do
       @obj = build(:dataset,
         custom_property_attributes: [{
           label: 'Local date'


### PR DESCRIPTION
This addresses https://github.com/antleaf/nims-mdr-development/issues/141 : responding to user feedback about metadata form usability. Sorry  it might have been better if I had made my pull request in smaller chunks.

* Reordered some metadata fields
* Hide fields that were deemed to be either confusing when users are depositing new data, don't make much sense, or are covered by other fields in the complex types -- and do not need to be editable by users
* Made some fields required. Some of these (complex types) have semantic difficulties as pointed out by @paulwalk  on Slack.
* Deleted some items from the "resource type" authority file
* Added "other" to some authority files
* Moved required metadata fields in the second tab to the first tab
* Changed some labels
* Hid the link to batch upload