### PR TITLE
Fix for #69

### DIFF
--- a/hyrax/app/actors/hyrax/actors/concerns/complex_attributes.rb
+++ b/hyrax/app/actors/hyrax/actors/concerns/complex_attributes.rb
@@ -1,0 +1,28 @@
+module Hyrax
+  module Actors
+    module ComplexAttributes
+      def update(env)
+        env = clean_complex_metadata(env)
+        super
+      end
+
+      def complex_objects
+        %w[
+          complex_person complex_identifier complex_affiliation complex_organization
+          complex_date complex_rights complex_version complex_relation instrument_function
+          custom_property complex_instrument manufacturer complex_specimen_type
+        ]
+      end
+
+      # delete all complex_metadata, it will be re-added during update
+      def clean_complex_metadata(env)
+        complex_objects.each do |complex|
+          if env.attributes["#{complex}_attributes"]
+            env.curation_concern[complex].each(&:destroy)
+          end
+        end
+        env
+      end
+    end
+  end
+end

--- a/hyrax/app/actors/hyrax/actors/dataset_actor.rb
+++ b/hyrax/app/actors/hyrax/actors/dataset_actor.rb
@@ -3,6 +3,7 @@
 module Hyrax
   module Actors
     class DatasetActor < Hyrax::Actors::BaseActor
+      include Hyrax::Actors::ComplexAttributes
     end
   end
 end

--- a/hyrax/app/actors/hyrax/actors/image_actor.rb
+++ b/hyrax/app/actors/hyrax/actors/image_actor.rb
@@ -3,6 +3,7 @@
 module Hyrax
   module Actors
     class ImageActor < Hyrax::Actors::BaseActor
+      include Hyrax::Actors::ComplexAttributes
     end
   end
 end

--- a/hyrax/app/actors/hyrax/actors/publication_actor.rb
+++ b/hyrax/app/actors/hyrax/actors/publication_actor.rb
@@ -3,6 +3,7 @@
 module Hyrax
   module Actors
     class PublicationActor < Hyrax::Actors::BaseActor
+      include Hyrax::Actors::ComplexAttributes
     end
   end
 end

--- a/hyrax/app/actors/hyrax/actors/work_actor.rb
+++ b/hyrax/app/actors/hyrax/actors/work_actor.rb
@@ -3,6 +3,7 @@
 module Hyrax
   module Actors
     class WorkActor < Hyrax::Actors::BaseActor
+      include Hyrax::Actors::ComplexAttributes
     end
   end
 end


### PR DESCRIPTION
This fixes #69. 

It adds some code into the actor stack to destroy complex attributes before update. It is a little brute force and I could rework it to look through the attributes and only destroy those that have a matching id in the incoming data.