### PR TITLE
WIP: oai-pmh, jpcoar

### DIFF
--- a/hyrax/app/models/document/jpcoar.rb
+++ b/hyrax/app/models/document/jpcoar.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'builder'
+
+# This module provide Jpcoar export based on the document's semantic values
+module Document::Jpcoar
+  def self.extended(document)
+    # Register our exportable formats
+    Document::Jpcoar.register_export_formats(document)
+  end
+
+  def self.register_export_formats(document)
+    document.will_export_as(:jpcoar_xml, 'text/xml')
+  end
+
+  # JA - these are taken from formats/jpcoar (although there are two 'version' (datacite and openaire) so I've just used datacite)
+  # JA - I've done these as hashes so we can map field name to the field with the correct namespace / name
+  # JA - the namespace bit might be wrong, we may just want them all to be jpcoar?
+  def jpcoar_field_names
+    { title: 'dc:title',
+      alternative: 'dcterms:alternative',
+      creator: 'jpcoar:creator',
+      contributor: 'jpcoar:contributor',
+      access_rights: 'dcterms:accessRights',
+      apc: 'rioxxterms:apc',
+      rights: 'dc:rights',
+      rights_older: 'jpcoar:rightsHolder',
+      subject: 'jpcoar:subject',
+      description: 'datacite:description',
+      publisher: 'dc:publisher',
+      date: 'datacite:date',
+      language: 'dc:language',
+      type: 'dc:type',
+      version: 'datacite:version',
+      identifier: 'jpcoar:identifier',
+      identifier_registration: 'jpcoar:identifierRegistration',
+      relation: 'jpcoar:relation',
+      temporal: 'dcterms:temporal',
+      geo_location: 'datacite:geoLocation',
+      funding_reference: 'jpcoar:fundingReference',
+      source_identifier: 'jpcoar:sourceIdentifier',
+      source_title: 'jpcoar:sourceTitle',
+      volume: 'jpcoar:volume',
+      issue: 'jpcoar:issue',
+      num_pages: 'jpcoar:numPages',
+      page_start: 'jpcoar:pageStart',
+      page_end: 'jpcoar:pageEnd',
+      dissertation_number: 'dcndl:dissertationNumber',
+      degree_name: 'dcndl:degreeName',
+      dateGranted: 'dcndl:dateGranted',
+      degree_grantor: 'jpcoar:degreeGrantor',
+      conference: 'jpcoar:conference',
+      file: 'jpcoar:file' }
+  end
+
+  # jpcoar elements are mapped against the #jpcoar_field_names whitelist.
+  # JA - I think jpcoar is a nested xml so this will need to be refactored
+  def export_as_jpcoar_xml
+    xml = Builder::XmlMarkup.new
+    xml.tag!('jpcoar',
+             'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
+             'xmlns:dcterms' => 'http://purl.org/dc/terms/',
+             'xmlns:rioxxterms' => 'http://www.rioxx.net/schema/v2.0/rioxxterms/',
+             'xmlns:datacite' => 'https://schema.datacite.org/meta/kernel-4/',
+             'xmlns:openaire' => 'http://namespace.openaire.eu/schema/oaire/',
+             'xmlns:dcndl' => 'http://ndl.go.jp/dcndl/terms/',
+             'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+             'xsi:schemaLocation ' => 'https://github.com/JPCOAR/schema/blob/master/1.0/jpcoar_scm.xsd') do
+      to_semantic_values.select { |field, _values| jpcoar_field_name? field }.each do |field, values|
+        Array.wrap(values).each do |v|
+          xml.tag! jpcoar_field_names[field], v
+        end
+      end
+    end
+    xml.target!
+  end
+
+  private
+
+  def jpcoar_field_name?(field)
+    jpcoar_field_names.keys.include? field.to_sym
+  end
+end

--- a/hyrax/app/models/metadata/jpcoar.rb
+++ b/hyrax/app/models/metadata/jpcoar.rb
@@ -1,10 +1,58 @@
 # The JPCOAR metadata format for MDR
 class Metadata::Jpcoar < OAI::Provider::Metadata::Format
-
+  
   def initialize
     @prefix = 'jpcoar'
     @schema = 'https://github.com/JPCOAR/schema/blob/master/1.0/jpcoar_scm.xsd'
     @namespace = 'https://github.com/JPCOAR/schema/blob/master/1.0/'
+    @element_namespace = 'jpcoar'
+    @fields = %i[title
+                 alternative
+                 creator
+                 contributor
+                 accessRights
+                 apc
+                 rights
+                 rightsHolder
+                 subject
+                 description
+                 publisher
+                 date
+                 language
+                 type
+                 version
+                 version
+                 identifier
+                 identifierRegistration
+                 relation
+                 temporal
+                 geoLocation
+                 fundingReference
+                 sourceIdentifier
+                 sourceTitle
+                 volume
+                 issue
+                 numPages
+                 pageStart
+                 pageEnd
+                 dissertationNumber
+                 degreeName
+                 dateGranted
+                 degreeGrantor
+                 conference
+                 file]
   end
 
+  def header_specification
+    {
+      'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
+      'xmlns:dcterms' => 'http://purl.org/dc/terms/',
+      'xmlns:rioxxterms' => 'http://www.rioxx.net/schema/v2.0/rioxxterms/',
+      'xmlns:datacite' => 'https://schema.datacite.org/meta/kernel-4/',
+      'xmlns:openaire' => 'http://namespace.openaire.eu/schema/oaire/',
+      'xmlns:dcndl' => 'http://ndl.go.jp/dcndl/terms/',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation ' => 'https://github.com/JPCOAR/schema/blob/master/1.0/jpcoar_scm.xsd'
+    }
+  end
 end

--- a/hyrax/app/models/solr_document.rb
+++ b/hyrax/app/models/solr_document.rb
@@ -21,51 +21,80 @@ class SolrDocument
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
+  # JA - add blacklight document for jpcoar
+  use_extension(Document::Jpcoar)
+
+  # JA - add field_semantics for oai_dc
+  field_semantics.merge!(
+    contributor: '', # @todo - extract anything other than author from complex person, may need new solr field
+    creator: 'complex_person_author_tesim',
+    date: 'date_tesim',
+    description: 'description_tesim',
+    identifier: 'complex_identifier_tesim', # @todo
+    language: 'language_tesim',
+    publisher: 'publisher_tesim',
+    relation: '', # @todo have a think about what to map here
+    rights: 'rights_tesim',
+    subject: 'subject_tesim',
+    title: 'title_tesim',
+    type: 'resource_type_tesim'
+    # todo add jpcoar fields
+  )
+
+  # JA - to_jpcoar
+  def to_jpcoar
+    export_as('jpcoar_xml')
+  end
 
   # Do content negotiation for AF models.
 
   use_extension( Hydra::ContentNegotiation )
 
-  include Formats::OaiDc
-  include Formats::Jpcoar
+  # JA - I wasn't sure whether the OaiDc was needed as I think Blacklight::Document::DublinCore is doing this already, when used with field_semantics I added
+  # include Formats::OaiDc
 
-  def process_mapping(xml, field, mapping)
-    if mapping.present?
-      if mapping.is_a?(Array)
-        mapping.each do |mapping_item|
-          # recurse and process each item in the array
-          process_mapping(xml, field, mapping_item)
-        end
+  # I think my Document::Jpcoar above is doing the same as Jpcoar here, but needs additional processing
+  # include Formats::Jpcoar
 
-      elsif mapping.is_a?(Hash)
-        if mapping[:field].present?
-          Array.wrap(self[mapping[:field]]).each do |unparsed_value|
-            value = self.send(mapping[:'function'], unparsed_value, mapping[:'argument'] || '.')
-            xml.tag! field, value if value.present?
-          end
-        elsif mapping[:function].present?
-          value = self.send(mapping[:'function'], field, xml)
-        else
-          puts "WARNING: mapping #{mapping.inspect} is ignored"
-        end
+  # JA - commented out during testing Document::Jpcoar
+  #  I think this can be moved into Document::Jpcoar and used for building the xml there
+  # def process_mapping(xml, field, mapping)
+  #   if mapping.present?
+  #     if mapping.is_a?(Array)
+  #       mapping.each do |mapping_item|
+  #         # recurse and process each item in the array
+  #         process_mapping(xml, field, mapping_item)
+  #       end
 
-      elsif mapping.is_a?(String)
-        Array.wrap(self[mapping]).each do |value|
-          xml.tag! field, value
-        end
-      end
+  #     elsif mapping.is_a?(Hash)
+  #       if mapping[:field].present?
+  #         Array.wrap(self[mapping[:field]]).each do |unparsed_value|
+  #           value = self.send(mapping[:'function'], unparsed_value, mapping[:'argument'] || '.')
+  #           xml.tag! field, value if value.present?
+  #         end
+  #       elsif mapping[:function].present?
+  #         value = self.send(mapping[:'function'], field, xml)
+  #       else
+  #         puts "WARNING: mapping #{mapping.inspect} is ignored"
+  #       end
 
-    end
-  end
+  #     elsif mapping.is_a?(String)
+  #       Array.wrap(self[mapping]).each do |value|
+  #         xml.tag! field, value
+  #       end
+  #     end
 
-  def xml_parse_and_select(unparsed_value, xpath_select)
-    # using some caching to avoid re-parsing the same content
-    key = unparsed_value.hash
-    @parsed_xml ||= {}
-    @parsed_xml[key] ||=  Nokogiri::XML(JSON.parse(unparsed_value).to_xml(root: 'root'))
+  #   end
+  # end
 
-    @parsed_xml[key].xpath(xpath_select)
-  end
+  # def xml_parse_and_select(unparsed_value, xpath_select)
+  #   # using some caching to avoid re-parsing the same content
+  #   key = unparsed_value.hash
+  #   @parsed_xml ||= {}
+  #   @parsed_xml[key] ||=  Nokogiri::XML(JSON.parse(unparsed_value).to_xml(root: 'root'))
+
+  #   @parsed_xml[key].xpath(xpath_select)
+  # end
 
   def alternative_title
     self[Solrizer.solr_name('alternative_title', :stored_searchable)]


### PR DESCRIPTION
I've prefaced comments with JA - so you can easily see what I've done, and where more work is needed.

oai_dc is returning metadata now, although it needs more field mapping

I've gone some way to the jpcoar ... I have a rudimentary implementation of an export, called with #to_jpcoar from the solr_document. It will need more work, and possibly more solr fields defining in indexers

the format is listed in oai-pmh (which you had setup already), but it just shows an error when calling for that format, eg.
localhost/catalog/oai?verb=GetRecord&metadataPrefix=jpcoar&identifier=ngdrdemo:z316q156s

I haven't figured that part out yet