### PR TITLE
Fix importer

### DIFF
--- a/hyrax/app/indexers/complex_field/date_indexer.rb
+++ b/hyrax/app/indexers/complex_field/date_indexer.rb
@@ -34,7 +34,7 @@ module ComplexField
         vals = d.date.reject(&:blank?)
         fld_name = Solrizer.solr_name("complex_date_#{label}", :dateable)
         solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
-        solr_doc[fld_name] << vals.map { |dt| DateTime.parse(dt).utc.iso8601 }
+        solr_doc[fld_name] << vals.map { |dt| dt.length <= 4 ? DateTime.strptime(dt, '%Y').utc.iso8601 : DateTime.parse(dt).utc.iso8601 }
         solr_doc[fld_name].flatten!
         # date as complex_date_type displayable
         fld_name = Solrizer.solr_name("complex_date_#{label}", :displayable)

--- a/hyrax/app/indexers/complex_field/date_indexer.rb
+++ b/hyrax/app/indexers/complex_field/date_indexer.rb
@@ -12,14 +12,15 @@ module ComplexField
       solr_doc[Solrizer.solr_name('complex_date', :displayable)] = object.complex_date.to_json
       # date as complex_date searchable
       dates = object.complex_date.map { |d| d.date.reject(&:blank?) }.flatten
-      dates_utc = dates.map { |d| DateTime.parse(d).utc.iso8601 } unless dates.blank?
+      # cope with just a year being supplied
+      dates_utc = dates.map { |d| d.length <= 4 ? DateTime.strptime(d, '%Y').utc.iso8601 : DateTime.parse(d).utc.iso8601 } unless dates.blank?
       solr_doc[Solrizer.solr_name('complex_date', :stored_searchable, type: :date)] = dates_utc unless dates.blank?
       solr_doc[Solrizer.solr_name('complex_date', :dateable)] = dates_utc unless dates.blank?
       object.complex_date.each do |d|
         next if d.date.reject(&:blank?).blank?
         label = 'other'
         unless d.description.blank?
-          # Finding it's display label for indexing
+          # Finding its display label for indexing
           term = DateService.new.find_by_id(d.description.first)
           label = term['label'] if term.any?
         end

--- a/hyrax/lib/importers/hyrax_importer.rb
+++ b/hyrax/lib/importers/hyrax_importer.rb
@@ -139,7 +139,7 @@ module Importers
       def update_work
         raise "Object doesn't exist" unless @object
         @object.update(update_attributes)
-        @object.depositor = @depositor
+        @object.depositor = @depositor.username
       end
 
       def update_work_by_actor


### PR DESCRIPTION
`DateTime.parse()` can't handle a year on its own, unless you give it the format specifically. 
https://github.com/antleaf/nims-mdr-development/issues/168