### PR TITLE
run apk command as root

### DIFF
--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,2 +1,3 @@
 FROM solr:7-alpine
+USER root
 RUN apk add poppler-data


### PR DESCRIPTION
The change in https://github.com/antleaf/nims-hyrax/pull/105 works on Linux, but doesn't work on 
macOS (See the following error). The ``apk add`` command should be run as root.

```
$ ngdrdocker build
redis uses an image, skipping
appdb uses an image, skipping
fcrepodb uses an image, skipping
fcrepo uses an image, skipping
db uses an image, skipping
Building solr
Step 1/2 : FROM solr:7-alpine
 ---> 64cb096f9679
Step 2/2 : RUN apk add poppler-data
 ---> Running in d77ab9d444c3
ERROR: Unable to lock database: Permission denied
ERROR: Failed to open apk database: Permission denied
ERROR: Service 'solr' failed to build: The command '/bin/sh -c apk add poppler-data' returned a non-zero code: 99
```