### PR TITLE
set dummy supervisor_approval for imported items

### DIFF
--- a/hyrax/lib/importers/publication_importer/importer.rb
+++ b/hyrax/lib/importers/publication_importer/importer.rb
@@ -60,6 +60,8 @@ module Importers
           if attributes.any? and attributes.fetch(:visibility, nil).blank?
             attributes[:visibility] = 'restricted'
           end
+          # set dummy supervisor approval
+          attributes[:supervisor_approval] = ['imported from PubMan']
           # Get files
           files_list = get_components(item)
           files = files_list[:files]


### PR DESCRIPTION
We would like to set a dummy value "imported from PubMan" for ``supervisor_approval`` property.
https://github.com/antleaf/nims-mdr-development/issues/150#issuecomment-531188918