### PR TITLE
Use proper work type in persistent_url

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -94,3 +94,5 @@ LDAP_SSL=false
 
 SMTP_HOST=
 SMTP_PORT=
+
+MDR_HOST=

--- a/hyrax/app/models/concerns/hyrax/solr_document/mdr_export.rb
+++ b/hyrax/app/models/concerns/hyrax/solr_document/mdr_export.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  module SolrDocument
+    module MdrExport
+      def persistent_url
+        Rails.application.routes.url_helpers.polymorphic_url(self)
+      end
+    end
+  end
+end
+
+SolrDocument.include Hyrax::SolrDocument::MdrExport

--- a/hyrax/app/models/concerns/hyrax/solr_document/mdr_export.rb
+++ b/hyrax/app/models/concerns/hyrax/solr_document/mdr_export.rb
@@ -7,5 +7,3 @@ module Hyrax
     end
   end
 end
-
-SolrDocument.include Hyrax::SolrDocument::MdrExport

--- a/hyrax/app/models/solr_document.rb
+++ b/hyrax/app/models/solr_document.rb
@@ -5,6 +5,7 @@ class SolrDocument
 
   # Adds Hyrax behaviors to the SolrDocument.
   include Hyrax::SolrDocumentBehavior
+  include Hyrax::SolrDocument::MdrExport
 
   # self.unique_key = 'id'
 

--- a/hyrax/config/environments/production.rb
+++ b/hyrax/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
     config.force_ssl = false
   else
     config.force_ssl = true #default if nothing specified is more secure.
-    Rails.application.routes.default_url_options[:protocol] = 'https'
+    Rails.application.routes.default_url_options = {protocol: 'https', host: ENV['MDR_HOST']}
   end
 
   # Use the lowest log level (:debug) to ensure availability of diagnostic information

--- a/hyrax/config/environments/test.rb
+++ b/hyrax/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  Rails.application.routes.default_url_options = {protocol: 'http', host: 'localhost'}
 end

--- a/hyrax/spec/models/solr_document_spec.rb
+++ b/hyrax/spec/models/solr_document_spec.rb
@@ -317,4 +317,10 @@ RSpec.describe SolrDocument do
     subject { solr_document.status }
     it { is_expected.to eql ['Status'] }
   end
+
+  describe '#persistent_url' do
+    let(:model) { build(:dataset, id: '123456', title: ['Test']) }
+    subject { solr_document.persistent_url }
+    it { is_expected.to eql "http://localhost/concern/datasets/#{solr_document.id}" }
+  end
 end

--- a/hyrax/spec/models/solr_document_spec.rb
+++ b/hyrax/spec/models/solr_document_spec.rb
@@ -318,9 +318,21 @@ RSpec.describe SolrDocument do
     it { is_expected.to eql ['Status'] }
   end
 
-  describe '#persistent_url' do
+  describe '#persistent_url (Dataset)' do
     let(:model) { build(:dataset, id: '123456', title: ['Test']) }
     subject { solr_document.persistent_url }
     it { is_expected.to eql "http://localhost/concern/datasets/#{solr_document.id}" }
+  end
+
+  describe '#persistent_url (Image)' do
+    let(:model) { build(:image, id: '123456', title: ['Test']) }
+    subject { solr_document.persistent_url }
+    it { is_expected.to eql "http://localhost/concern/images/#{solr_document.id}" }
+  end
+
+  describe '#persistent_url (Publication)' do
+    let(:model) { build(:publication, id: '123456', title: ['Test']) }
+    subject { solr_document.persistent_url }
+    it { is_expected.to eql "http://localhost/concern/publications/#{solr_document.id}" }
   end
 end


### PR DESCRIPTION
This pull request is to fix URL in a EndNote export file.
https://github.com/antleaf/nims-mdr-development/issues/182

Please set ``MDR_HOST`` environment variable in order to set the default host name.