### PR TITLE
Extract full text on plain text files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   solr:
   db:
   db-fcrepo:
+  app:
 
 networks:
   internal:
@@ -90,6 +91,10 @@ services:
         AIRBRAKE_PROJECT_KEY: ${AIRBRAKE_PROJECT_KEY}
     env_file:
       - .env
+    volumes:
+      - app:${UPLOADS_PATH}
+      - app:${DERIVATIVES_PATH}
+      - app:${CACHE_PATH}
     networks:
       internal:
 

--- a/hyrax/app/models/file_set.rb
+++ b/hyrax/app/models/file_set.rb
@@ -6,9 +6,10 @@ class FileSet < ActiveFedora::Base
   end
 
   include ::Hyrax::FileSetBehavior
-  # override method in  lib/hydra/works/models/concerns/file_set/mime_types.rb
-  #   add text/plain
-  def office_document_mime_types
+  
+  # override method in lib/hydra/works/models/concerns/file_set/mime_types.rb
+    #   add text/plain
+  def self.office_document_mime_types
     ['text/plain',
      'text/rtf',
      'application/msword',

--- a/hyrax/app/models/file_set.rb
+++ b/hyrax/app/models/file_set.rb
@@ -6,4 +6,17 @@ class FileSet < ActiveFedora::Base
   end
 
   include ::Hyrax::FileSetBehavior
+  # override method in  lib/hydra/works/models/concerns/file_set/mime_types.rb
+  #   add text/plain
+  def office_document_mime_types
+    ['text/plain',
+     'text/rtf',
+     'application/msword',
+     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+     'application/vnd.oasis.opendocument.text',
+     'application/vnd.ms-excel',
+     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+     'application/vnd.ms-powerpoint',
+     'application/vnd.openxmlformats-officedocument.presentationml.presentation']
+  end
 end

--- a/hyrax/spec/models/file_set_spec.rb
+++ b/hyrax/spec/models/file_set_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FileSet do
-  it "has tests" do
-    skip "Add your tests here"
+  it "adds plain text to office_document_mime_types" do
+    expect(described_class.office_document_mime_types).to include('text/plain')
   end
 end


### PR DESCRIPTION
This PR adds plain text to `FileSet.office_document_mime_types` and should mean the full_text extraction service runs.

One problem I hit during testing - the workers and web docker containers were not sharing a volume, so the workers couldn't find the files they wanted to run jobs against. I added a shared volume to `docker-compose.yml`, although I'm not sure why this hasn't been a problem before.

The txt file attached to this work contains the words random and randomness:
<img width="771" alt="Screenshot 2019-10-17 at 12 11 47" src="https://user-images.githubusercontent.com/722117/67004091-6387f480-f0d7-11e9-8ba0-bb7b2f4e85ad.png">

Caveat: note the strange thumbnail, this is the result of including plain text files in the office_document_mime_types array. Thumbnail show next to the actual file contents below:
<img width="480" alt="Screenshot 2019-10-17 at 12 14 48" src="https://user-images.githubusercontent.com/722117/67004247-c9747c00-f0d7-11e9-9560-a28d49e1faf3.png">

