### PR TITLE
Add the languages vocab task to setup_hyrax

### DIFF
--- a/hyrax/lib/tasks/setup_hyrax.rake
+++ b/hyrax/lib/tasks/setup_hyrax.rake
@@ -45,5 +45,10 @@ namespace :ngdr do
     Rake::Task['hyrax:default_admin_set:create'].invoke
     Rake::Task['hyrax:workflow:load'].invoke
     Rake::Task['hyrax:default_collection_types:create'].invoke
+
+    ##############################################
+    # Create languages controlled vocabulary
+    ######
+    Rake::Task['hyrax:controlled_vocabularies:language'].invoke if Qa::Authorities::Local.subauthority_for('languages').all.size == 0
   end
 end


### PR DESCRIPTION
This will run `hyrax:controlled_vocabularies:language` when it hasn't already been run.

Languages are drawn from Lexvo.

<img width="718" alt="Screenshot 2019-10-17 at 12 25 55" src="https://user-images.githubusercontent.com/722117/67005033-8f0bde80-f0d9-11e9-9141-651785c09a7d.png">
