### PR TITLE
Allow the data dir to be set by an env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -46,6 +46,8 @@ GA_PRIVATE_KEY_SECRET=
 GA_CLIENT_EMAIL=
 
 # Hyrax application setting
+# NB: in macOS Catalina (10.15) the /srv/ path is not available to Docker
+HOST_APP_DATA_PATH=/srv/ngdr/data/
 DERIVATIVES_PATH=/shared/derivatives/
 FITS_PATH=/fits/fits-1.3.0/fits.sh
 # fits_version should appear exactly like this, including fits-

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,7 +32,7 @@ services:
       - file_uploads:${UPLOADS_PATH}
       - derivatives:${DERIVATIVES_PATH}
       - cache:${CACHE_PATH}
-      - /srv/ngdr/data/:/data/data
+      - ${HOST_APP_DATA_PATH:-/srv/ngdr/data/}:/data/data
 
   web:
     ports:


### PR DESCRIPTION
Fixes problem with running Docker in macOS Catalina 10.15

If you have have a problem running NIMS in Docker on macOS Catalina 10.15 with an error message like:

> ERROR: for app  Cannot start service app: 'Mounts denied: The path /srv/ngdr/data is not shared from OS X and is not known to Docker...'


This can be resolved by changing (or adding if it doesn't exist) the value of `HOST_APP_DATA_PATH` in the `.env` file from `/srv/ngdr/data/` to a path which the Docker daemon has access to, e.g.

```
HOST_APP_DATA_PATH=/Users/my-user-name/nims-hyrax.data/srv/ngdr/data/
```