### PR TITLE
i212 - search links not working

### DIFF
--- a/hyrax/app/indexers/complex_field/purchase_record_indexer.rb
+++ b/hyrax/app/indexers/complex_field/purchase_record_indexer.rb
@@ -20,6 +20,11 @@ module ComplexField
         vals = st.complex_purchase_record.map { |i| i.title.reject(&:blank?) }
         solr_doc[fld_name] << vals
         solr_doc[fld_name].flatten!
+        fld_name = Solrizer.solr_name('complex_purchase_record_title', :facetable)
+        solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
+        vals = st.complex_purchase_record.map { |i| i.title.reject(&:blank?) }
+        solr_doc[fld_name] << vals
+        solr_doc[fld_name].flatten!
         st.complex_purchase_record.each do |i|
           # date
           dates = i.date.reject(&:blank?)
@@ -87,6 +92,7 @@ module ComplexField
     def self.purchase_record_facet_fields
       # solr fields that will be treated as facets
       fields = []
+      # fields << Solrizer.solr_name('complex_purchase_record_title', :facetable)
       fields << Solrizer.solr_name('complex_purchase_record_manufacturer', :facetable)
       fields << Solrizer.solr_name('complex_purchase_record_manufacturer_sub_organization', :facetable)
       fields << Solrizer.solr_name('complex_purchase_record_supplier', :facetable)

--- a/hyrax/app/indexers/dataset_indexer.rb
+++ b/hyrax/app/indexers/dataset_indexer.rb
@@ -27,7 +27,8 @@ class DatasetIndexer < NgdrIndexer
         'computational_methods',
         'data_origin',
         'properties_addressed',
-        'synthesis_and_processing'
+        'synthesis_and_processing',
+        'characterization_methods'
       ]
       dataset_facet_fields.each do |fld|
         fields << Solrizer.solr_name(fld, :facetable)

--- a/hyrax/app/models/dataset.rb
+++ b/hyrax/app/models/dataset.rb
@@ -52,7 +52,7 @@ class Dataset < ActiveFedora::Base
   property :complex_organization, predicate: ::RDF::Vocab::ORG.organization, class_name:"ComplexOrganization"
 
   property :characterization_methods, predicate: ::RDF::Vocab::NimsRdp['characterization-methods'], multiple: false do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   property :computational_methods, predicate: ::RDF::Vocab::NimsRdp['computational-methods'], multiple: false do |index|

--- a/hyrax/app/renderers/nested_affiliation_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_affiliation_attribute_renderer.rb
@@ -13,7 +13,7 @@ class NestedAffiliationAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_organization').blank?
         label = 'Organization'
         renderer_class = NestedOrganizationAttributeRenderer
-        each_html += get_nested_output(label, v['complex_organization'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_organization'], renderer_class, false)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/app/renderers/nested_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_attribute_renderer.rb
@@ -48,12 +48,12 @@ class NestedAttributeRenderer < Hyrax::Renderers::FacetedAttributeRenderer
     row
   end
 
-  def get_nested_output(label, nested_value, renderer_class, display_label=false)
+  def get_nested_output(field, label, nested_value, renderer_class, display_label=false)
     output_html = ''
     unless nested_value.kind_of?(Array)
       nested_value = [nested_value]
     end
-    renderer = renderer_class.new(label, nested_value)
+    renderer = renderer_class.new(get_field(field, label), nested_value)
     nested_value.each do |val|
       inner_html = renderer.attribute_value_to_html(val)
       unless inner_html.blank?
@@ -82,5 +82,25 @@ class NestedAttributeRenderer < Hyrax::Renderers::FacetedAttributeRenderer
       html_out += '</div>'
     end
     html_out
+  end
+
+  # map the field/label pair to the correct facet search link
+  def get_field(field, label)
+    case
+    when field == :complex_person && label == 'Organization'
+      :complex_person_organization
+    when field == :complex_instrument && label == 'Manufacturer'
+      :instrument_manufacturer
+    when field == :complex_instrument && label == 'Operator'
+      :complex_person_operator
+    when field == :complex_instrument && label == 'Managing organization'
+      :instrument_managing_organization
+    when field == :complex_specimen_type && label == 'Supplier'
+      :complex_purchase_record_supplier
+    when field == :complex_specimen_type && label == 'Manufacturer'
+      :complex_purchase_record_manufacturer
+    else
+      field
+    end
   end
 end

--- a/hyrax/app/renderers/nested_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_attribute_renderer.rb
@@ -99,6 +99,8 @@ class NestedAttributeRenderer < Hyrax::Renderers::FacetedAttributeRenderer
       :complex_purchase_record_supplier
     when field == :complex_specimen_type && label == 'Manufacturer'
       :complex_purchase_record_manufacturer
+    when field == :complex_person_operator && label == 'Organization'
+      :complex_person_operator_organization
     else
       field
     end

--- a/hyrax/app/renderers/nested_desc_id_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_desc_id_attribute_renderer.rb
@@ -13,7 +13,7 @@ class NestedDescIdAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/app/renderers/nested_instrument_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_instrument_attribute_renderer.rb
@@ -8,6 +8,7 @@ class NestedInstrumentAttributeRenderer < NestedAttributeRenderer
       # title
       if v.dig('title').present? and v['title'][0].present?
         label ="Title"
+        # @todo - fixme
         val = link_to(ERB::Util.h(v['title'][0]), search_path(v['title'][0]))
         each_html += get_row(label, val)
       end
@@ -21,7 +22,7 @@ class NestedInstrumentAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_date').blank?
         label = 'Date'
         renderer_class = NestedDateAttributeRenderer
-        each_html += get_nested_output(label, v['complex_date'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_date'], renderer_class, false)
       end
       # description
       unless v.dig('description').blank?
@@ -33,19 +34,19 @@ class NestedInstrumentAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # instrument function
       unless v.dig('instrument_function').blank?
         label = 'Instrument function'
         renderer_class = NestedInstrumentFunctionAttributeRenderer
-        each_html += get_nested_output(label, v['instrument_function'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['instrument_function'], renderer_class, true)
       end
       # manufacturer
       unless v.dig('manufacturer').blank?
         label = 'Manufacturer'
         renderer_class = NestedOrganizationAttributeRenderer
-        each_html += get_nested_output(label, v['manufacturer'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['manufacturer'], renderer_class, true)
       end
       # model_number
       unless v.dig('model_number').blank?
@@ -57,13 +58,13 @@ class NestedInstrumentAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_person').blank?
         label = 'Operator'
         renderer_class = NestedPersonAttributeRenderer
-        each_html += get_nested_output(label, v['complex_person'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_person'], renderer_class, true)
       end
       # managing_organization
       unless v.dig('managing_organization').blank?
         label = 'Managing organization'
         renderer_class = NestedOrganizationAttributeRenderer
-        each_html += get_nested_output(label, v['managing_organization'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['managing_organization'], renderer_class, true)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/app/renderers/nested_material_type_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_material_type_attribute_renderer.rb
@@ -19,7 +19,7 @@ class NestedMaterialTypeAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # description
       unless v.dig('description').blank?

--- a/hyrax/app/renderers/nested_organization_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_organization_attribute_renderer.rb
@@ -23,7 +23,7 @@ class NestedOrganizationAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/app/renderers/nested_person_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_person_attribute_renderer.rb
@@ -29,13 +29,13 @@ class NestedPersonAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # complex_affiliation
       unless v.dig('complex_affiliation').blank?
         label = 'Affiliation'
         renderer_class = NestedAffiliationAttributeRenderer
-        each_html += get_nested_output(label, v['complex_affiliation'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_affiliation'], renderer_class, true)
       end
       # role
       unless v.dig('role').blank?

--- a/hyrax/app/renderers/nested_purchase_record_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_purchase_record_attribute_renderer.rb
@@ -8,7 +8,10 @@ class NestedPurchaseRecordAttributeRenderer < NestedAttributeRenderer
       # title
       if v.dig('title').present? and v['title'][0].present?
         label ="Title"
-        val = link_to(ERB::Util.h(v['title'][0]), search_path(v['title'][0]))
+        # call search_catalog_path directly to get correct search link
+        val = link_to(ERB::Util.h(v['title'][0]),
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[complex_purchase_record_title_sim][]" => v['title'][0], locale: I18n.locale)
+        )
         each_html += get_row(label, val)
       end
       # date
@@ -19,19 +22,19 @@ class NestedPurchaseRecordAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # supplier
       unless v.dig('supplier').blank?
         label = 'Supplier'
         renderer_class = NestedOrganizationAttributeRenderer
-        each_html += get_nested_output(label, v['supplier'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['supplier'], renderer_class, true)
       end
       # manufacturer
       unless v.dig('manufacturer').blank?
         label = 'Manufacturer'
         renderer_class = NestedOrganizationAttributeRenderer
-        each_html += get_nested_output(label, v['manufacturer'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['manufacturer'], renderer_class, true)
       end
       # purchase_record_item
       unless v.dig('purchase_record_item').blank?

--- a/hyrax/app/renderers/nested_relation_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_relation_attribute_renderer.rb
@@ -19,7 +19,7 @@ class NestedRelationAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # Relationship
       unless v.dig('relationship').blank?

--- a/hyrax/app/renderers/nested_source_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_source_attribute_renderer.rb
@@ -19,12 +19,12 @@ class NestedSourceAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_person').blank?
         label = 'Contributor'
         renderer_class = NestedPersonAttributeRenderer
-        each_html += get_nested_output(label, v['complex_person'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_person'], renderer_class, true)
       end
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       unless v.dig('issue').blank?
         label = 'Issue'

--- a/hyrax/app/renderers/nested_specimen_type_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_specimen_type_attribute_renderer.rb
@@ -15,13 +15,13 @@ class NestedSpecimenTypeAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_chemical_composition').blank?
         label = 'Chemical composition'
         renderer_class = NestedDescIdAttributeRenderer
-        each_html += get_nested_output(label, v['complex_chemical_composition'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_chemical_composition'], renderer_class, true)
       end
       # complex_crystallographic_structure
       unless v.dig('complex_crystallographic_structure').blank?
         label = 'Crystallographic structure'
         renderer_class = NestedDescIdAttributeRenderer
-        each_html += get_nested_output(label, v['complex_crystallographic_structure'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_crystallographic_structure'], renderer_class, true)
       end
       # description
       unless v.dig('description').blank?
@@ -33,37 +33,37 @@ class NestedSpecimenTypeAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       # complex_material_type
       unless v.dig('complex_material_type').blank?
         label = 'Material type'
         renderer_class = NestedMaterialTypeAttributeRenderer
-        each_html += get_nested_output(label, v['complex_material_type'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_material_type'], renderer_class, true)
       end
       # complex_purchase_record
       unless v.dig('complex_purchase_record').blank?
         label = 'Purchase record'
         renderer_class = NestedPurchaseRecordAttributeRenderer
-        each_html += get_nested_output(label, v['complex_purchase_record'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_purchase_record'], renderer_class, true)
       end
       # complex_shape
       unless v.dig('complex_shape').blank?
         label = 'Shape'
         renderer_class = NestedDescIdAttributeRenderer
-        each_html += get_nested_output(label, v['complex_shape'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_shape'], renderer_class, true)
       end
       # complex_state_of_matter
       unless v.dig('complex_state_of_matter').blank?
         label = 'State of matter'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_state_of_matter'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_state_of_matter'], renderer_class, true)
       end
       # complex_structural_feature
       unless v.dig('complex_structural_feature').blank?
         label = 'Structural feature'
         renderer_class = NestedStructuralFeatureAttributeRenderer
-        each_html += get_nested_output(label, v['complex_structural_feature'], renderer_class, true)
+        each_html += get_nested_output(field, label, v['complex_structural_feature'], renderer_class, true)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/app/renderers/nested_structural_feature_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_structural_feature_attribute_renderer.rb
@@ -27,7 +27,7 @@ class NestedStructuralFeatureAttributeRenderer < NestedAttributeRenderer
       unless v.dig('complex_identifier').blank?
         label = 'Identifier'
         renderer_class = NestedIdentifierAttributeRenderer
-        each_html += get_nested_output(label, v['complex_identifier'], renderer_class, false)
+        each_html += get_nested_output(field, label, v['complex_identifier'], renderer_class, false)
       end
       html += get_inner_html(each_html)
     end

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -6,6 +6,7 @@ en:
         facet:
           based_near_label_sim: Location
           creator_sim: Creator
+          characterization_methods_sim: Characterization methods
           complex_date_dtsim: Date
           complex_date_accepted_dtsim: Date accepted
           complex_date_available_dtsim: Date available

--- a/hyrax/features/datasets/search_links.feature
+++ b/hyrax/features/datasets/search_links.feature
@@ -18,10 +18,17 @@ Feature: Search links on a dataset
       | with_complex_version                    |
 
 
-  Scenario: search links find the dataset
-    Given I am on dataset page
-    Then I see the following links:
-      | LABEL            | HREF                                                             |
-      | Anamika          | /catalog?f%5Bcomplex_person_sim%5D%5B%5D=Anamika                 |
-      | University       | /catalog?f%5Bcomplex_person_organization_sim%5D%5B%5D=University |
-      | Instrument title | /catalog?f%5Bcomplex_instrument_sim%5D%5B%5D=Instrument+title    |
+  Scenario: Search links are generated correctly
+    Given I am on the dataset page
+    Then I should see the following links:
+      | LABEL                      | HREF                                                                                  |
+      | Anamika                    | /catalog?f%5Bcomplex_person_sim%5D%5B%5D=Anamika                                      |
+      | University                 | /catalog?f%5Bcomplex_person_organization_sim%5D%5B%5D=University                      |
+      | Instrument title           | /catalog?f%5Bcomplex_instrument_sim%5D%5B%5D=Instrument+title                         |
+      | Foo                        | /catalog?f%5Binstrument_manufacturer_sim%5D%5B%5D=Foo                                 |
+      | Name of operator           | /catalog?f%5Bcomplex_person_operator_sim%5D%5B%5D=Name+of+operator                    |
+      | University                 | /catalog?f%5Bcomplex_person_operator_sim%5D%5B%5D=University                          |
+      | Managing organization name | /catalog?f%5Binstrument_managing_organization_sim%5D%5B%5D=Managing+organization+name |
+      | Purchase record title      | /catalog?f%5Bcomplex_purchase_record_title_sim%5D%5B%5D=Purchase+record+title         |
+      | Fooss                      | /catalog?f%5Bcomplex_purchase_record_supplier_sim%5D%5B%5D=Fooss                      |
+      | Foo                        | /catalog?f%5Bcomplex_purchase_record_manufacturer_sim%5D%5B%5D=Foo                    |

--- a/hyrax/features/datasets/search_links.feature
+++ b/hyrax/features/datasets/search_links.feature
@@ -27,7 +27,7 @@ Feature: Search links on a dataset
       | Instrument title           | /catalog?f%5Bcomplex_instrument_sim%5D%5B%5D=Instrument+title                         |
       | Foo                        | /catalog?f%5Binstrument_manufacturer_sim%5D%5B%5D=Foo                                 |
       | Name of operator           | /catalog?f%5Bcomplex_person_operator_sim%5D%5B%5D=Name+of+operator                    |
-      | University                 | /catalog?f%5Bcomplex_person_operator_sim%5D%5B%5D=University                          |
+      | University                 | /catalog?f%5Bcomplex_person_operator_organization_sim%5D%5B%5D=University             |
       | Managing organization name | /catalog?f%5Binstrument_managing_organization_sim%5D%5B%5D=Managing+organization+name |
       | Purchase record title      | /catalog?f%5Bcomplex_purchase_record_title_sim%5D%5B%5D=Purchase+record+title         |
       | Fooss                      | /catalog?f%5Bcomplex_purchase_record_supplier_sim%5D%5B%5D=Fooss                      |

--- a/hyrax/features/datasets/search_links.feature
+++ b/hyrax/features/datasets/search_links.feature
@@ -1,0 +1,27 @@
+Feature: Search links on a dataset
+  Background:
+    Given an initialised sysem with a default admin set, permission template and workflow
+    And there is a dataset with:
+      | TRAIT                                   |
+      | open                                    |
+      | with_complex_person                     |
+      | with_complex_author                     |
+      | with_complex_chemical_composition       |
+      | with_complex_crystallographic_structure |
+      | with_custom_property                    |
+      | with_complex_date                       |
+      | with_complex_identifier                 |
+      | with_complex_instrument                 |
+      | with_complex_specimen_type              |
+      | with_complex_relation                   |
+      | with_complex_rights                     |
+      | with_complex_version                    |
+
+
+  Scenario: search links find the dataset
+    Given I am on dataset page
+    Then I see the following links:
+      | LABEL            | HREF                                                             |
+      | Anamika          | /catalog?f%5Bcomplex_person_sim%5D%5B%5D=Anamika                 |
+      | University       | /catalog?f%5Bcomplex_person_organization_sim%5D%5B%5D=University |
+      | Instrument title | /catalog?f%5Bcomplex_instrument_sim%5D%5B%5D=Instrument+title    |

--- a/hyrax/features/step_definitions/dataset_steps.rb
+++ b/hyrax/features/step_definitions/dataset_steps.rb
@@ -6,6 +6,16 @@ Given(/^there (?:are|is) (\d+) (open|authenticated|embargo|lease|restricted) dat
   ActiveFedora::SolrService.commit
 end
 
+Given(/^there is a dataset with:$/) do |table|
+  @dataset = FactoryBot.create(:dataset, *table.rows.flatten.map(&:to_sym))
+  ActiveFedora::SolrService.add(@dataset.to_solr)
+  ActiveFedora::SolrService.commit
+end
+
+Given(/^I am on dataset page$/) do
+  visit hyrax_dataset_path(@dataset)
+end
+
 When(/^I navigate to the new dataset page$/) do
   visit '/dashboard'
   click_link "Works"

--- a/hyrax/features/step_definitions/dataset_steps.rb
+++ b/hyrax/features/step_definitions/dataset_steps.rb
@@ -12,7 +12,7 @@ Given(/^there is a dataset with:$/) do |table|
   ActiveFedora::SolrService.commit
 end
 
-Given(/^I am on dataset page$/) do
+Given(/^I am on the dataset page$/) do
   visit hyrax_dataset_path(@dataset)
 end
 
@@ -90,5 +90,11 @@ Then(/^I should not see the (open|authenticated|embargo|lease|restricted) datase
   # next, verify there is a link to each dataset (using a regular expression to allow for the locale parameter)
   @datasets[access].each do |dataset|
     expect(page).to_not have_link(dataset.title.first, href: Regexp.new(hyrax_dataset_path(dataset)))
+  end
+end
+
+Then(/^I should see the following links:$/) do |table|
+  table.symbolic_hashes.each do |row|
+    expect(page).to have_link(row[:label], href: Regexp.new(Regexp.quote(row[:href])))
   end
 end

--- a/hyrax/spec/factories/dataset.rb
+++ b/hyrax/spec/factories/dataset.rb
@@ -173,7 +173,7 @@ FactoryBot.define do
              }]
           }],
           managing_organization_attributes: [{
-            organization: 'FooFoo',
+            organization: 'Managing organization name',
             sub_organization: 'BarBar',
             purpose: 'Managing organization',
             complex_identifier_attributes: [{

--- a/hyrax/spec/indexers/dataset_indexer_spec.rb
+++ b/hyrax/spec/indexers/dataset_indexer_spec.rb
@@ -337,7 +337,14 @@ RSpec.describe DatasetIndexer do
         model_number: '123xfty',
         complex_person_attributes: [{
           name: ['Name of operator'],
-          role: ['Operator']
+          role: ['Operator'],
+          complex_affiliation_attributes: [{
+            job_title: 'Technician',
+            complex_organization_attributes: [{
+              organization: 'Org 1',
+              sub_organization: 'Sub org 1'
+            }]
+          }]
         }],
         managing_organization_attributes: [{
           organization: 'FooFoo',
@@ -378,7 +385,14 @@ RSpec.describe DatasetIndexer do
         model_number: 'ABC12E',
         complex_person_attributes: [{
           name: ['Name of operator 2'],
-          role: ['Operator']
+          role: ['Operator'],
+          complex_affiliation_attributes: [{
+            job_title: 'Technician',
+            complex_organization_attributes: [{
+              organization: 'Org 2',
+              sub_organization: 'Sub org 2'
+            }]
+          }]
         }],
         managing_organization_attributes: [{
           organization: 'BigBig',
@@ -397,6 +411,9 @@ RSpec.describe DatasetIndexer do
     it 'indexes as displayable' do
       expect(@solr_document).to include('complex_instrument_ssm')
       expect(JSON.parse(@solr_document['complex_instrument_ssm'])).not_to be_empty
+    end
+    it 'indexes title as facetable to complex_instrument_sim' do
+      expect(@solr_document['complex_instrument_sim']).to match_array(['Instrument title', 'Instrument title 2'])
     end
     it 'indexes title as stored searchable' do
       expect(@solr_document['instrument_title_tesim']).to match_array(['Instrument title', 'Instrument title 2'])
@@ -437,8 +454,14 @@ RSpec.describe DatasetIndexer do
     it 'indexes person by role as stored searchable' do
       expect(@solr_document['complex_person_operator_tesim']).to match_array(['Name of operator', 'Name of operator 2'])
     end
-    it 'imdexes person by role as facetable' do
+    it 'indexes person by role as facetable' do
       expect(@solr_document['complex_person_operator_sim']).to match_array(['Name of operator', 'Name of operator 2'])
+    end
+    it 'indexes person affiliation by role as stored searchable' do
+      expect(@solr_document['complex_person_operator_organization_tesim']).to match_array(["Org 1", "Org 2"])
+    end
+    it 'indexes person affiliation by role as facetable' do
+      expect(@solr_document['complex_person_operator_organization_sim']).to match_array(["Org 1", "Org 2"])
     end
     it 'indexes managing organization as stored searchable' do
       expect(@solr_document['instrument_managing_organization_tesim']).to match_array(['FooFoo', 'BigBig'])
@@ -795,6 +818,10 @@ RSpec.describe DatasetIndexer do
     end
     it 'indexes purchase record title as stored_searchable' do
       expect(@solr_document['complex_purchase_record_title_tesim']).to match_array(
+        ['Purchase record title', 'Purchase record title 2', 'Purchase record title 3'])
+    end
+    it 'indexes purchase record title as facetable' do
+      expect(@solr_document['complex_purchase_record_title_sim']).to match_array(
         ['Purchase record title', 'Purchase record title 2', 'Purchase record title 3'])
     end
     it 'indexes purchase record date as dateable' do

--- a/hyrax/spec/indexers/dataset_indexer_spec.rb
+++ b/hyrax/spec/indexers/dataset_indexer_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe DatasetIndexer do
           }]
         }],
         managing_organization_attributes: [{
-          organization: 'FooFoo',
+          organization: 'Managing organization name',
           sub_organization: 'BarBar',
           purpose: 'Managing organization',
           complex_identifier_attributes: [{
@@ -464,10 +464,10 @@ RSpec.describe DatasetIndexer do
       expect(@solr_document['complex_person_operator_organization_sim']).to match_array(["Org 1", "Org 2"])
     end
     it 'indexes managing organization as stored searchable' do
-      expect(@solr_document['instrument_managing_organization_tesim']).to match_array(['FooFoo', 'BigBig'])
+      expect(@solr_document['instrument_managing_organization_tesim']).to match_array(['Managing organization name', 'BigBig'])
     end
     it 'indexes managing organization as facetable' do
-      expect(@solr_document['instrument_managing_organization_sim']).to match_array(['FooFoo', 'BigBig'])
+      expect(@solr_document['instrument_managing_organization_sim']).to match_array(['Managing organization name', 'BigBig'])
     end
     it 'indexes managing sub organization as stored searchable' do
       expect(@solr_document['instrument_managing_sub_organization_tesim']).to match_array(['BarBar', 'BazBaz'])

--- a/hyrax/spec/inputs/nested_instrument_input_spec.rb
+++ b/hyrax/spec/inputs/nested_instrument_input_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe NestedInstrumentInput, type: :input do
     is_expected.to have_field('dataset[instrument_attributes][0][complex_person_attributes][0][complex_affiliation_attributes][0]_complex_organization_attributes_0_sub_organization', type: :text, with: 'Department')
     is_expected.to have_field('dataset[instrument_attributes][0][complex_person_attributes][0][complex_affiliation_attributes][0]_complex_organization_attributes_0_purpose', type: :text, with: 'Research')
 
-    is_expected.to have_field('dataset[instrument_attributes][0]_managing_organization_attributes_0_organization', type: :text, with: 'FooFoo')
+    is_expected.to have_field('dataset[instrument_attributes][0]_managing_organization_attributes_0_organization', type: :text, with: 'Managing organization name')
     is_expected.to have_field('dataset[instrument_attributes][0]_managing_organization_attributes_0_sub_organization', type: :text, with: 'BarBar')
     is_expected.to have_field('dataset[instrument_attributes][0]_managing_organization_attributes_0_purpose', type: :text, with: 'Managing organization')
   end

--- a/hyrax/spec/models/concerns/complex_instrument_spec.rb
+++ b/hyrax/spec/models/concerns/complex_instrument_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe ComplexInstrument do
               role: ['Operator']
             }],
             managing_organization_attributes: [{
-              organization: 'FooFoo',
+              organization: 'Managing organization name',
               sub_organization: 'BarBar',
               purpose: 'Managing organization',
               complex_identifier_attributes: [{
@@ -126,7 +126,7 @@ RSpec.describe ComplexInstrument do
         expect(subject.complex_person.first.name).to eq ['Name of operator']
         expect(subject.complex_person.first.role).to eq ['Operator']
         expect(subject.managing_organization.first).to be_kind_of ActiveTriples::Resource
-        expect(subject.managing_organization.first.organization).to eq ['FooFoo']
+        expect(subject.managing_organization.first.organization).to eq ['Managing organization name']
         expect(subject.managing_organization.first.sub_organization).to eq ['BarBar']
         expect(subject.managing_organization.first.purpose).to eq ['Managing organization']
         expect(subject.managing_organization.first.complex_identifier.first.identifier).to eq ['123456789mo']

--- a/hyrax/spec/models/dataset_spec.rb
+++ b/hyrax/spec/models/dataset_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Dataset do
       expect(@obj.complex_instrument.first.complex_person.first.name).to eq ['Name of operator']
       expect(@obj.complex_instrument.first.complex_person.first.role).to eq ['operator']
       expect(@obj.complex_instrument.first.managing_organization.first).to be_kind_of ActiveTriples::Resource
-      expect(@obj.complex_instrument.first.managing_organization.first.organization).to eq ['FooFoo']
+      expect(@obj.complex_instrument.first.managing_organization.first.organization).to eq ['Managing organization name']
       expect(@obj.complex_instrument.first.managing_organization.first.sub_organization).to eq ['BarBar']
       expect(@obj.complex_instrument.first.managing_organization.first.purpose).to eq ['Managing organization']
       expect(@obj.complex_instrument.first.managing_organization.first.complex_identifier.first.identifier).to eq ['123456789mo']

--- a/hyrax/spec/renderers/nested_instrument_attribute_renderer_spec.rb
+++ b/hyrax/spec/renderers/nested_instrument_attribute_renderer_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe NestedInstrumentAttributeRenderer do
 
     is_expected.to have_css('div.row label', text: 'Managing organization')
     is_expected.to have_css('div.row label', text: 'Organization')
-    is_expected.to have_css('div.row a', text: 'FooFoo')
+    is_expected.to have_css('div.row a', text: 'Managing organization name')
 
     is_expected.to have_css('div.row label', text: 'Sub organization')
     is_expected.to have_css('div.row', text: 'BarBar')


### PR DESCRIPTION
This issue was largely caused by how the search links are being constructed in the show page. Where these are nested properties the search link is being constructed with the label and not the field. However, the field refers to the wider resource (eg. instrument, rather than operator) so the solution I have come up with is to use both the field and the label to construct the search link, eg. where the (containing) field is `complex_instrument` and the label is `Manufacturer`, we can construct the correct search link for `instrument_manufacturer`. This approach fixes the following search links:

* Creator -> Organization
* Instrument -> Manufacturer -> Organisation
* Instrument -> Operator -> Name
* Instrument -> Managing organization -> Organization
* Instrument -> Affiliation -> Organization
* Specimen type -> Supplier -> Organization
* Specimen type -> Manufacturer -> Organization

For, `Specimen type -> Purchase record -> Title` the search link is constructed directly in the renderer (`NestedPurchaseRecordAttributeRenderer`) as Title is not a complex field, and so does not call the method using the solution above.

In some cases, fields were not indexed as facetable and therefore the searches would fail. The following are now indexed as facetable:

* Characterization methods
* Instrument -> Title
* Specimen type -> Purchase record -> Title
* Instrument -> Affiliation -> Organization

Please note, Purchase record title and Instrument Title have *not* been added as facets in the search results page, but the search link now works.

Tests have been added to the indexer, but ideally we should have a view test to check that the search links are properly constructed. Because this solution relies on the label, if a label were to change, it would break the search link. 