### PR TITLE
Fix Error in Citations with a DOI

### DIFF
--- a/hyrax/app/helpers/hyrax/citations_behaviors/publication_behavior.rb
+++ b/hyrax/app/helpers/hyrax/citations_behaviors/publication_behavior.rb
@@ -7,8 +7,11 @@ module Hyrax
 
       # nims override to add doi
       def setup_doi(presenter)
-        return '' if presenter.complex_identifier == ["[]"]
-        JSON.parse(presenter.complex_identifier).
+        ci = presenter.complex_identifier
+        if presenter.complex_identifier.is_a?(Array)
+          ci = presenter.complex_identifier.first
+        end
+        JSON.parse(ci).
             select{|i| i["scheme"].any?{|s| s =~/doi/i} }.
             pluck('identifier').
             flatten.


### PR DESCRIPTION
I am unsure why this is happening, but when `Hyrax::CitationsBehaviors::PublicationBehavior#setup_doi` calls `presenter.complex_identifier`, it is receiving an Array, which cannot then be parsed with JSON.parse and an error is thrown.

The test for this passes because `presenter.complex_identifier` returns a String. The same happens if I create the presenter in the rails console - it's a String.

So it's not at all clear why in the code itself, it's an Array. 

This code fixes it, but doesn't explain it.