### PR TITLE
Changes to ease local testing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -85,8 +85,8 @@ BOX_CLIENT_SECRET=
 
 # Choose one of the following authentication methods.
 # (database_authenticatable is pre-configured and useful for a development environment)
-MDR_DEVISE_AUTH_MODULE=ldap_authenticatable
-# MDR_DEVISE_AUTH_MODULE=database_authenticatable
+# MDR_DEVISE_AUTH_MODULE=ldap_authenticatable
+MDR_DEVISE_AUTH_MODULE=database_authenticatable
 
 LDAP_HOST=***REMOVED***
 LDAP_PORT=443

--- a/hyrax/Gemfile
+++ b/hyrax/Gemfile
@@ -75,7 +75,9 @@ gem 'devise_ldap_authenticatable'
 
 gem 'riiif', '~> 2.0'
 
-gem 'airbrake', '~> 5.0'
+group :production do
+  gem 'airbrake', '~> 5.0'
+end
 
 gem 'willow_sword', git: 'https://github.com/CottageLabs/willow_sword.git', :branch => 'feature/prep_for_new_release'
 gem 'blacklight_oai_provider', git: 'https://github.com/CottageLabs/blacklight_oai_provider.git', branch: 'master'

--- a/hyrax/Gemfile
+++ b/hyrax/Gemfile
@@ -75,9 +75,7 @@ gem 'devise_ldap_authenticatable'
 
 gem 'riiif', '~> 2.0'
 
-group :production do
-  gem 'airbrake', '~> 5.0'
-end
+gem 'airbrake', '~> 5.0'
 
 gem 'willow_sword', git: 'https://github.com/CottageLabs/willow_sword.git', :branch => 'feature/prep_for_new_release'
 gem 'blacklight_oai_provider', git: 'https://github.com/CottageLabs/blacklight_oai_provider.git', branch: 'master'

--- a/hyrax/config/initializers/errbit.rb
+++ b/hyrax/config/initializers/errbit.rb
@@ -1,12 +1,14 @@
-if ENV.fetch('AIRBRAKE_HOST', nil).present? and
-  ENV.fetch('AIRBRAKE_PROJECT_ID', nil).present? and
-  ENV.fetch('AIRBRAKE_PROJECT_KEY', nil).present?
-  Airbrake.configure do |config|
-    config.host = ENV['AIRBRAKE_HOST']
-    config.project_id = ENV['AIRBRAKE_PROJECT_ID']
-    config.project_key = ENV['AIRBRAKE_PROJECT_KEY']
-    # setting for the rails app
-    config.environment = Rails.env
-    config.ignore_environments = %w(development test)
-  end
+# frozen_string_literal: true
+
+Airbrake.configure do |config|
+  # setting for the rails app
+  config.environment = Rails.env
+  config.ignore_environments = %w[development test]
+  # ignore production if the environment variables aren't set
+  config.ignore_environments << 'production' if ENV.fetch('AIRBRAKE_HOST', nil).blank? &&
+                                                ENV.fetch('AIRBRAKE_PROJECT_ID', nil).blank? &&
+                                                ENV.fetch('AIRBRAKE_PROJECT_KEY', nil).blank?
+  config.host = ENV['AIRBRAKE_HOST']
+  config.project_id = ENV['AIRBRAKE_PROJECT_ID']
+  config.project_key = ENV['AIRBRAKE_PROJECT_KEY']
 end

--- a/hyrax/config/initializers/errbit.rb
+++ b/hyrax/config/initializers/errbit.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
-
-Airbrake.configure do |config|
-  # setting for the rails app
-  config.environment = Rails.env
-  config.ignore_environments = %w[development test]
-  # ignore production if the environment variables aren't set
-  config.ignore_environments << 'production' if ENV.fetch('AIRBRAKE_HOST', nil).blank? &&
-                                                ENV.fetch('AIRBRAKE_PROJECT_ID', nil).blank? &&
-                                                ENV.fetch('AIRBRAKE_PROJECT_KEY', nil).blank?
-  config.host = ENV['AIRBRAKE_HOST']
-  config.project_id = ENV['AIRBRAKE_PROJECT_ID']
-  config.project_key = ENV['AIRBRAKE_PROJECT_KEY']
+if Rails.env == 'production'
+  Airbrake.configure do |config|
+    # setting for the rails app
+    config.environment = Rails.env
+    config.ignore_environments = %w[development test]
+    # ignore production if the environment variables aren't set
+    config.ignore_environments << 'production' if ENV.fetch('AIRBRAKE_HOST', nil).blank? &&
+                                                  ENV.fetch('AIRBRAKE_PROJECT_ID', nil).blank? &&
+                                                  ENV.fetch('AIRBRAKE_PROJECT_KEY', nil).blank?
+    config.host = ENV['AIRBRAKE_HOST']
+    config.project_id = ENV['AIRBRAKE_PROJECT_ID']
+    config.project_key = ENV['AIRBRAKE_PROJECT_KEY']
+  end
 end


### PR DESCRIPTION
Trying to use docker locally in production to test the versioning issue, I hit a couple of issues which took a while to sort out:
* an error was being captured by airbrake and causing an airbrake error (so I didn't know what the original error was), even though the config was setup to skip - reading up on this, the config MUST be set, so I've refactored this to add production to the ignored environments if the AIRBRAKE env variables aren't set
* turns out the *real* error was ldap - I've switched .env.template back to having db auth as default as this is the most likely for use in development