### PR TITLE
Index identifier by scheme

### DIFF
--- a/hyrax/app/indexers/complex_field/identifier_indexer.rb
+++ b/hyrax/app/indexers/complex_field/identifier_indexer.rb
@@ -10,8 +10,8 @@ module ComplexField
       solr_doc[Solrizer.solr_name('complex_identifier', :symbol)] = object.complex_identifier.map { |i| i.identifier.reject(&:blank?).first }
       solr_doc[Solrizer.solr_name('complex_identifier', :displayable)] = object.complex_identifier.to_json
       object.complex_identifier.each do |i|
-        unless i.label.blank? || i.identifier.blank?
-          fld_name = Solrizer.solr_name("complex_identifier_#{i.label.reject(&:blank?).first.downcase.tr(' ', '_')}", :symbol)
+        unless i.scheme.blank? || i.identifier.blank?
+          fld_name = Solrizer.solr_name("complex_identifier_#{i.scheme.reject(&:blank?).first.downcase.tr(' ', '_')}", :symbol)
           solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
           solr_doc[fld_name] << i.identifier.reject(&:blank?)
           solr_doc[fld_name].flatten!

--- a/hyrax/spec/indexers/dataset_indexer_spec.rb
+++ b/hyrax/spec/indexers/dataset_indexer_spec.rb
@@ -49,14 +49,13 @@ RSpec.describe DatasetIndexer do
       ids = [
         {
           identifier: '0000-0000-0000-0000',
-          scheme: 'uri_of_ORCID_scheme',
-          label: 'ORCID'
+          scheme: 'ORCID'
         }, {
           identifier: '1234',
-          label: 'Local ID'
+          scheme: 'identifier local'
         }, {
           identifier: '12345345234',
-          label: 'Orcid'
+          scheme: 'Orcid'
         }
       ]
       obj = build(:dataset, complex_identifier_attributes: ids)
@@ -71,7 +70,7 @@ RSpec.describe DatasetIndexer do
     end
     it 'indexes each type as symbol' do
       expect(@solr_document['complex_identifier_orcid_ssim']).to match_array(['0000-0000-0000-0000', '12345345234'])
-      expect(@solr_document['complex_identifier_local_id_ssim']).to match_array(['1234'])
+      expect(@solr_document['complex_identifier_identifier_local_ssim']).to match_array(['1234'])
     end
   end
 

--- a/hyrax/spec/indexers/image_indexer_spec.rb
+++ b/hyrax/spec/indexers/image_indexer_spec.rb
@@ -49,14 +49,13 @@ RSpec.describe ImageIndexer do
       ids = [
         {
           identifier: '0000-0000-0000-0000',
-          scheme: 'uri_of_ORCID_scheme',
-          label: 'ORCID'
+          scheme: 'ORCID'
         }, {
           identifier: '1234',
-          label: 'Local ID'
+          scheme: 'identifier local'
         }, {
           identifier: '12345345234',
-          label: 'Orcid'
+          scheme: 'Orcid'
         }
       ]
       obj = build(:image, complex_identifier_attributes: ids)
@@ -71,7 +70,7 @@ RSpec.describe ImageIndexer do
     end
     it 'indexes each type as symbol' do
       expect(@solr_document['complex_identifier_orcid_ssim']).to match_array(['0000-0000-0000-0000', '12345345234'])
-      expect(@solr_document['complex_identifier_local_id_ssim']).to match_array(['1234'])
+      expect(@solr_document['complex_identifier_identifier_local_ssim']).to match_array(['1234'])
     end
   end
 

--- a/hyrax/spec/indexers/publication_indexer_spec.rb
+++ b/hyrax/spec/indexers/publication_indexer_spec.rb
@@ -49,14 +49,13 @@ RSpec.describe PublicationIndexer do
       ids = [
         {
           identifier: '0000-0000-0000-0000',
-          scheme: 'uri_of_ORCID_scheme',
-          label: 'ORCID'
+          scheme: 'ORCID'
         }, {
           identifier: '1234',
-          label: 'Local ID'
+          scheme: 'identifier local'
         }, {
           identifier: '12345345234',
-          label: 'Orcid'
+          scheme: 'Orcid'
         }
       ]
       obj = build(:publication, complex_identifier_attributes: ids)
@@ -71,7 +70,7 @@ RSpec.describe PublicationIndexer do
     end
     it 'indexes each type as symbol' do
       expect(@solr_document['complex_identifier_orcid_ssim']).to match_array(['0000-0000-0000-0000', '12345345234'])
-      expect(@solr_document['complex_identifier_local_id_ssim']).to match_array(['1234'])
+      expect(@solr_document['complex_identifier_identifier_local_ssim']).to match_array(['1234'])
     end
   end
 


### PR DESCRIPTION
This PR fixes what I believe is a bug in `IdentiferIndexer`. The intention is to index all identifiers by scheme in the following form:

```
complex_identifier_doi_ssim
complex_identifier_local_identifier_ssim
```

The original code used the complex_identifier label to achieve this, but this is not populated AFAIK whereas scheme is always populated and in fact provides a simpler and shorter indexing key. This PR switches to using scheme in place of label, and fixes the corresponding test.
