### PR TITLE
Hide Collections

### DIFF
--- a/hyrax/app/views/hyrax/base/_guts4form.html.erb
+++ b/hyrax/app/views/hyrax/base/_guts4form.html.erb
@@ -1,6 +1,6 @@
 <% # we will yield to content_for for each tab, e.g. :files_tab %>
 <% # Override Hyrax 2.6 - remove relationships tab from here %>
-<% tabs ||= %w[metadata method instrument specimen files] # default tab order %>
+<% tabs ||= %w[metadata files] # default tab order %>
 <div class="row">
   <div class="col-xs-12 col-sm-8">
     <div class="panel panel-default tabs" role="main">

--- a/hyrax/app/views/hyrax/base/_show_actions.html.erb
+++ b/hyrax/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,50 @@
+<div class="show-actions">
+  <% if Hyrax.config.analytics? %>
+    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
+  <% end %>
+  <% if presenter.editor? %>
+      <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
+      <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+      <% if presenter.member_presenters.size > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Attach Child <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
+        </div>
+      <% end %>
+  <% end %>
+	<% # Override Hyrax 2.6 - remove add to collection button %>
+  <%
+=begin%>
+ <% if presenter.show_deposit_for?(collections: @user_collections) %>
+      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                     class: 'btn btn-default submits-batches submits-batches-add',
+                     data: { toggle: "modal", target: "#collection-list-container" } %>
+  <% end %> 
+<%
+=end%>
+  <% if presenter.work_featurable? %>
+      <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'feature' },
+          class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+
+      <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'unfeature' },
+          class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+  <% end %>
+</div>
+
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/hyrax/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/hyrax/app/views/hyrax/batch_uploads/_form.html.erb
@@ -1,0 +1,22 @@
+<%= simple_form_for [hyrax, @form],
+                    html: {
+                      data: { behavior: 'work-form',
+                              'param-key' => @form.model_name.param_key },
+                      multipart: true
+                    } do |f| %>
+  <% provide :files_tab do %>
+    <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
+    <p class="switch-upload-type"><%= t("hyrax.batch_uploads.files.upload_type_instructions") %>
+      <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
+    </p>
+  <% end %>
+	<% # Override Hyrax 2.6 - remove relationships tab from here %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata] %>
+  <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'batch-template-download')
+  });
+</script>

--- a/hyrax/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/hyrax/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,0 +1,14 @@
+<li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+  <% # Override Hyrax 2.6 - restrict collections to admins %>
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.my_collections_path,
+                      also_active_for: hyrax.dashboard_collections_path) do %>
+      <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+    <% end %>
+  <% end %>
+
+  <%= menu.nav_link(hyrax.my_works_path,
+                    also_active_for: hyrax.dashboard_works_path) do %>
+    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+  <% end %>

--- a/hyrax/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/hyrax/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
+  let(:work) { Publication.new }
+  let(:ability) { double }
+  let(:user) { FactoryBot.build(:user) }
+
+  let(:form) do
+    Hyrax::PublicationForm.new(work, ability, controller)
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    assign(:form, form)
+  end
+
+  describe 'tabs' do
+    it 'does not show the relationships tab' do
+      render
+      expect(rendered).not_to have_selector('#relationships[role="tabpanel"]')
+      expect(rendered).to have_selector('#metadata[role="tabpanel"]')
+      expect(rendered).to have_selector('#files[role="tabpanel"]')
+      expect(rendered).to have_selector('#share[data-param-key="publication"]')
+    end
+  end
+end

--- a/hyrax/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/hyrax/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability) }
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:attributes) { { 'has_model_ssim' => ['Publication'], :id => '0r967372b' } }
+  let(:ability) { double }
+
+  before do
+    allow(ability).to receive(:can?).with(:create, FeaturedWork).and_return(false)
+    allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(true)
+    allow(presenter).to receive(:editor?).and_return(true)
+  end
+
+  context 'as a registered user' do
+    it 'shows edit / delete / Add to collection links' do
+      render 'hyrax/base/show_actions', presenter: presenter
+
+      expect(rendered).to have_link 'Edit'
+      expect(rendered).to have_link 'Delete'
+      expect(rendered).not_to have_link 'Add to collection'
+      expect(rendered).not_to have_button 'Add to collection'
+    end
+  end
+end

--- a/hyrax/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/hyrax/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
+  let(:work) { Publication.new }
+  let(:ability) { double('ability', current_user: user) }
+  let(:user) { FactoryBot.build(:user) }
+
+  let(:form) do
+    Hyrax::Forms::BatchUploadForm.new(work, ability, controller)
+  end
+
+  before do
+    view.lookup_context.prefixes += ['hyrax/base']
+    allow(controller).to receive(:current_user).and_return(user)
+    assign(:form, form)
+  end
+
+  describe 'tabs' do
+    it 'does not show the relationships tab' do
+      render
+      expect(rendered).not_to have_selector('#relationships[role="tabpanel"]')
+      expect(rendered).to have_selector('#metadata[role="tabpanel"]')
+      expect(rendered).to have_selector('#files[role="tabpanel"]')
+    end
+  end
+end

--- a/hyrax/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/hyrax/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
+  let(:user) { FactoryBot.build(:user) }
+  let(:can_result) { false }
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(user)
+    assign(:user, user)
+    allow(view).to receive(:can?).with(:read, :admin_dashboard).and_return(can_result)
+    allow(view).to receive(:can?).with(:manage_any, AdminSet).and_return(can_result)
+    allow(view).to receive(:can?).with(:review, :submissions).and_return(can_result)
+    allow(view).to receive(:can?).with(:manage, User).and_return(can_result)
+    allow(view).to receive(:can?).with(:update, :appearance).and_return(can_result)
+    allow(view).to receive(:can?).with(:manage, Hyrax::Feature).and_return(can_result)
+    allow(view).to receive(:can?).with(:manage, Sipity::WorkflowResponsibility).and_return(can_result)
+    allow(view).to receive(:can?).with(:manage, :collection_types).and_return(can_result)
+  end
+
+  context 'with any user' do
+    before do
+      render
+    end
+    subject { rendered }
+
+    it { is_expected.not_to have_link t('hyrax.admin.sidebar.collections') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.works') }
+  end
+
+  context 'with a user who can read the admin dashboard' do
+    let(:can_result) { true }
+
+    before do
+      render
+    end
+    subject { rendered }
+
+    it { is_expected.to have_link t('hyrax.admin.sidebar.collections') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.works') }
+  end
+end

--- a/hyrax/spec/views/hyrax/datasets/_form.html.erb_spec.rb
+++ b/hyrax/spec/views/hyrax/datasets/_form.html.erb_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/datasets/_form.html.erb', type: :view do
+  let(:work) { Dataset.new }
+  let(:ability) { double }
+  let(:user) { FactoryBot.build(:user) }
+
+  let(:form) do
+    Hyrax::DatasetForm.new(work, ability, controller)
+  end
+
+  before do
+    view.lookup_context.prefixes += ['hyrax/base']
+    allow(controller).to receive(:current_user).and_return(user)
+    assign(:form, form)
+  end
+
+  describe 'tabs' do
+    it 'does not show the relationships tab' do
+      render
+      expect(rendered).not_to have_selector('#relationships[role="tabpanel"]')
+      expect(rendered).to have_selector('#metadata[role="tabpanel"]')
+      expect(rendered).to have_selector('#files[role="tabpanel"]')
+      expect(rendered).to have_selector('#share[data-param-key="dataset"]')
+    end
+  end
+end


### PR DESCRIPTION
This PR:

* hides the relationship tab from the create/edit work and batch upload forms

<img width="569" alt="Screenshot 2019-12-11 at 19 10 31" src="https://user-images.githubusercontent.com/722117/70652473-8f90a380-1c4a-11ea-991a-14caa41dcc8d.png">

* hides Collections in the sidebar unless  you are an admin

Admin:
<img width="265" alt="Screenshot 2019-12-11 at 19 09 37" src="https://user-images.githubusercontent.com/722117/70652454-88699580-1c4a-11ea-95ef-8d1a62d08954.png">

Non Admin:
<img width="244" alt="Screenshot 2019-12-11 at 19 10 15" src="https://user-images.githubusercontent.com/722117/70652463-8b648600-1c4a-11ea-92a1-614f717dcbf9.png">
