### PR TITLE
Override file_set_actor to retain japanese characters

### DIFF
--- a/hyrax/config/initializers/file_set_actor_override.rb
+++ b/hyrax/config/initializers/file_set_actor_override.rb
@@ -1,0 +1,17 @@
+# Override Hyrax 2.6 to support Japanese characters in filenames
+# Use Addressable::URI.unencode rather than Addressable::URI.parse
+# PR to Hyrax 3.x https://github.com/samvera/hyrax/pull/4172
+Hyrax::Actors::FileSetActor.class_eval do
+  def label_for(file)
+    if file.is_a?(Hyrax::UploadedFile) # filename not present for uncached remote file!
+      file.uploader.filename.present? ? file.uploader.filename : File.basename(Addressable::URI.unencode(file.file_url))
+    elsif file.respond_to?(:original_name) # e.g. Hydra::Derivatives::IoDecorator
+      file.original_name
+    elsif file_set.import_url.present?
+      # This path is taken when file is a Tempfile (e.g. from ImportUrlJob)
+      File.basename(Addressable::URI.unencode(file.file_url))
+    else
+      File.basename(file)
+    end
+  end
+end


### PR DESCRIPTION
Before:
<img width="724" alt="Screenshot 2019-12-12 at 10 36 27" src="https://user-images.githubusercontent.com/722117/70707535-44b96f00-1cd0-11ea-812c-c77e221b3ecf.png">

After:
<img width="757" alt="Screenshot 2019-12-12 at 11 10 50" src="https://user-images.githubusercontent.com/722117/70707539-47b45f80-1cd0-11ea-9fb8-db9b199e3136.png">
