### PR TITLE
Use loofah to sanitize incoming form data

### DIFF
--- a/hyrax/app/controllers/concerns/complex_fields_behavior.rb
+++ b/hyrax/app/controllers/concerns/complex_fields_behavior.rb
@@ -100,13 +100,13 @@ module ComplexFieldsBehavior
     if value.is_a? Array
       value.map do |v|
         if v.is_a? String
-          Loofah.fragment(v).scrub!(:strip).to_s
+          Loofah.fragment(v).scrub!(:escape).to_s
         else
           v
         end
       end
     elsif value.is_a? String
-      Loofah.fragment(value).scrub!(:strip).to_s
+      Loofah.fragment(value).scrub!(:escape).to_s
     else
       value
     end

--- a/hyrax/app/controllers/concerns/complex_fields_behavior.rb
+++ b/hyrax/app/controllers/concerns/complex_fields_behavior.rb
@@ -1,62 +1,61 @@
 module ComplexFieldsBehavior
-
   private
 
   def is_complex?(attribute_name)
-    complex_prefixes = [
-      'complex',
-      'instrument_function',
-      'manufacturer',
-      'managing_organization',
-      'supplier',
-      'manufacturer',
-      'custom_property'
+    complex_prefixes = %w[
+      complex
+      instrument_function
+      manufacturer
+      managing_organization
+      supplier
+      manufacturer
+      custom_property
     ]
     complex_prefixes.each { |prefix| return true if attribute_name.to_s.start_with? prefix }
     false
   end
 
   def hash_is_blank?(hash_param)
-    other_keys = hash_param.keys - ['id', '_destroy']
+    other_keys = hash_param.keys - %w[id _destroy]
     return false unless other_keys.blank?
-    if hash_param.fetch('id', nil) and hash_param.fetch('_destroy', nil)
-      return false if hash_param['_destroy'] == "true"
+    if hash_param.fetch('id', nil) && hash_param.fetch('_destroy', nil)
+      return false if hash_param['_destroy'] == 'true'
     end
     true
   end
 
-  # Delete person/organization from instrument and specimen_type where the record contains 
+  # Delete person/organization from instrument and specimen_type where the record contains
   #   only role=operator (person) or purpose=manufacturer/supplier (organization)
   #   this happens because we are validating nothing on instrument or speciment_type
   # This is temporary until proper validation is in place
   def cleanup_instrument_and_specimen_type(attribute)
     # complex_instrument
-    attribute['complex_instrument_attributes'].each_with_index do | complex_instrument, index |
-      complex_instrument['complex_person_attributes'].each_with_index do | complex_person, i |
+    attribute['complex_instrument_attributes'].each_with_index do |complex_instrument, index|
+      complex_instrument['complex_person_attributes'].each_with_index do |complex_person, i|
         if complex_person['name'].blank? && complex_person['role'].include?('operator')
           attribute['complex_instrument_attributes'][index]['complex_person_attributes'].delete_at(i)
         end
       end
-      complex_instrument['manufacturer_attributes'].each_with_index do | manufacturer, i |
+      complex_instrument['manufacturer_attributes'].each_with_index do |manufacturer, i|
         if manufacturer['organization'].blank? && manufacturer['purpose'].include?('Manufacturer')
           attribute['complex_instrument_attributes'][index]['manufacturer_attributes'].delete_at(i)
         end
       end
-      complex_instrument['managing_organization_attributes'].each_with_index do | managing_organization, i |
+      complex_instrument['managing_organization_attributes'].each_with_index do |managing_organization, i|
         if managing_organization['organization'].blank? && managing_organization['purpose'].include?('Managing organization')
           attribute['complex_instrument_attributes'][index]['managing_organization_attributes'].delete_at(i)
         end
       end
     end
     # complex_specimen_type
-    attribute['complex_specimen_type_attributes'].each_with_index do | complex_specimen_type, index |
-      complex_specimen_type['complex_purchase_record_attributes'].each_with_index do | complex_purchase_record, i |
-        complex_purchase_record['supplier_attributes'].each_with_index do | supplier, ii |
+    attribute['complex_specimen_type_attributes'].each_with_index do |complex_specimen_type, index|
+      complex_specimen_type['complex_purchase_record_attributes'].each_with_index do |complex_purchase_record, i|
+        complex_purchase_record['supplier_attributes'].each_with_index do |supplier, ii|
           if supplier['organization'].blank? && supplier['purpose'].include?('Supplier')
             attribute['complex_specimen_type_attributes'][index]['complex_purchase_record_attributes'][i]['supplier_attributes'].delete_at(ii)
           end
         end
-        complex_purchase_record['manufacturer_attributes'].each_with_index do | manufacturer, ii |
+        complex_purchase_record['manufacturer_attributes'].each_with_index do |manufacturer, ii|
           if manufacturer['organization'].blank? && manufacturer['purpose'].include?('Manufacturer')
             attribute['complex_specimen_type_attributes'][index]['complex_purchase_record_attributes'][i]['manufacturer_attributes'].delete_at(ii)
           end
@@ -67,28 +66,27 @@ module ComplexFieldsBehavior
   end
 
   def cleanup_params(attribute)
-    if attribute.kind_of? Hash and attribute.keys.all? {|k| k !~ /\D/ }
+    if attribute.is_a?(Hash) && attribute.keys.all? { |k| k !~ /\D/ }
       # removes hashes with integer keys
       attribute = cleanup_params(attribute.values)
-    elsif attribute.kind_of? Hash
+    elsif attribute.is_a? Hash
       new_attribute = {}
       attribute.each do |k, v|
         v = cleanup_params(v) if is_complex?(k)
-        v = cleanup_params(v) if v.kind_of? Array
-        unless v.blank?
-          new_attribute[k] = v
-        end
+        v = cleanup_params(v) if v.is_a? Array
+        next if v.blank?
+        new_attribute[k] = if skip_controlled.include?(k) || k.end_with?('_attributes')
+                             v
+                           else
+                             sanitize_value(v)
+                           end
       end
-      unless hash_is_blank?(new_attribute)
-        new_attribute.compact
-      else
-        nil
-      end
-    elsif attribute.kind_of? Array
+      new_attribute.compact unless hash_is_blank?(new_attribute)
+    elsif attribute.is_a? Array
       new_attr = []
       attribute.reject(&:blank?).each do |v|
-        v = cleanup_params(v) if v.kind_of? Hash
-        new_attr << v unless v.blank?
+        v = cleanup_params(v) if v.is_a? Hash
+        new_attr << sanitize_value(v) unless v.blank?
       end
       new_attr.reject(&:blank?)
     elsif attribute.blank?
@@ -96,5 +94,41 @@ module ComplexFieldsBehavior
     else
       attribute
     end
+  end
+
+  def sanitize_value(value)
+    if value.is_a? Array
+      value.map do |v|
+        if v.is_a? String
+          Loofah.fragment(v).scrub!(:strip).to_s
+        else
+          v
+        end
+      end
+    elsif value.is_a? String
+      Loofah.fragment(value).scrub!(:strip).to_s
+    else
+      value
+    end
+  end
+
+  # Don't scrub controlled fields
+  def skip_controlled
+    %w[
+      representative_id
+      thumbnail_id
+      visibility_during_embargo
+      visibility_after_embargo
+      visibility_during_lease
+      visibility_after_lease
+      visibility
+      admin_set_id
+      data_origin
+      version
+      _destroy
+      id
+      purpose
+      role
+    ]
   end
 end

--- a/hyrax/db/schema.rb
+++ b/hyrax/db/schema.rb
@@ -279,7 +279,6 @@ ActiveRecord::Schema.define(version: 20191125140832) do
     t.string "uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["local_authority_id", "label"], name: "index_qa_local_authority_entries_on_lower_label"
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end


### PR DESCRIPTION
Screencast to show the sanitizing in action: https://share.getcloudapp.com/nOumLy2Y

I've used loofah to scrub the incoming form data. There are four options for how to have Loofah scrub the data. I have gone for 'strip' which strips out the tags, but leaves the data. Other options are whitewash, prune and escape - this can easily be changed ( @nabeta ):
https://github.com/flavorjones/loofah

- Using `strip` changes <script>alert('hello')</script> to `alert('hello')`
- `whitewash` and `prune` would remove the data completely
- `escape` would give us `&lt;script&gt;alert('hello')&lt;/script&gt;`
