### PR TITLE
Fix issue with "search for works" user profile

### DIFF
--- a/hyrax/app/views/hyrax/users/_vitals.html.erb
+++ b/hyrax/app/views/hyrax/users/_vitals.html.erb
@@ -1,0 +1,21 @@
+<%# Override Hyrax - fix bug with number of works search %>
+<div class="list-group-item">
+  <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= t("hyrax.dashboard.stats.joined_on") %> <%= user.created_at.to_date.strftime("%b %d, %Y") %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> 
+	<%= link_to t("hyrax.dashboard.stats.works"), main_app.search_catalog_path(f: {generic_type_sim: ['Collection'], depositor_ssim: [user.to_s]}) %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="glyphicon glyphicon-upload" aria-hidden="true"></span> 
+	<%= link_to t("hyrax.dashboard.stats.works"), main_app.search_catalog_path(f: {generic_type_sim: ['Work'], depositor_ssim: [user.to_s]}) %>
+
+  <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+  </ul>
+</div>


### PR DESCRIPTION
The PR re-writes the query in `app/views/hyrax/users/_vitals.html.erb` as the existing Hyrax form is broken.

There is an issue in Hyrax for this: https://github.com/samvera/hyrax/issues/3478 and it looks like it is slated for work by the Hyrax Maintenance Working Group. At that point this local override may be removed.

<img width="775" alt="Screenshot 2020-02-05 at 11 43 06" src="https://user-images.githubusercontent.com/722117/73838936-bc0d0a00-480c-11ea-9ea7-03af5e63c4f0.png">
