### PR TITLE
Use year instead of date in facet search

### DIFF
--- a/hyrax/app/indexers/complex_field/date_indexer.rb
+++ b/hyrax/app/indexers/complex_field/date_indexer.rb
@@ -23,7 +23,7 @@ module ComplexField
       # add year
       years = dates_utc.map {|d| DateTime.parse(d).strftime("%Y")} 
       solr_doc[Solrizer.solr_name('complex_year', :stored_searchable)] = years unless dates.blank?
-      solr_doc[Solrizer.solr_name('complex_', :facetable)] = years unless dates.blank?
+      solr_doc[Solrizer.solr_name('complex_year', :facetable)] = years unless dates.blank?
       object.complex_date.each do |d|
         next if d.date.reject(&:blank?).blank?
         label = 'other'

--- a/hyrax/app/indexers/complex_field/date_indexer.rb
+++ b/hyrax/app/indexers/complex_field/date_indexer.rb
@@ -20,6 +20,10 @@ module ComplexField
       end
       solr_doc[Solrizer.solr_name('complex_date', :stored_searchable, type: :date)] = dates_utc unless dates.blank?
       solr_doc[Solrizer.solr_name('complex_date', :dateable)] = dates_utc unless dates.blank?
+      # add year
+      years = dates_utc.map {|d| DateTime.parse(d).strftime("%Y")} 
+      solr_doc[Solrizer.solr_name('complex_year', :stored_searchable)] = years unless dates.blank?
+      solr_doc[Solrizer.solr_name('complex_', :facetable)] = years unless dates.blank?
       object.complex_date.each do |d|
         next if d.date.reject(&:blank?).blank?
         label = 'other'
@@ -39,11 +43,18 @@ module ComplexField
         fld_name = Solrizer.solr_name("complex_date_#{label}", :dateable)
         solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
         begin
-          solr_doc[fld_name] << vals.map{|d| d.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')}.map { |dt| dt.length <= 4 ? DateTime.strptime(dt, '%Y').utc.iso8601 : DateTime.parse(dt).utc.iso8601 }
+          dates_utc = vals.map{|d| d.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')}.map { |d| d.length <= 4 ? DateTime.strptime(d, '%Y').utc.iso8601 : DateTime.parse(d).utc.iso8601 } unless dates.blank?
         rescue ArgumentError
-          solr_doc[fld_name] << vals.map{|d| d.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')}.map { |dt| DateTime.parse("#{dt}-01").utc.iso8601 }
+          dates_utc = vals.map{|d| d.tr('０-９ａ-ｚＡ-Ｚ','0-9a-zA-Z')}.map { |d| DateTime.parse("#{d}-01").utc.iso8601 } unless dates.blank?
         end
+        solr_doc[fld_name] << dates_utc unless dates_utc.blank?
         solr_doc[fld_name].flatten!
+        # Add years
+        year_fld = Solrizer.solr_name("complex_year_#{label}", :facetable)
+        years = dates_utc.map {|d| DateTime.parse(d).strftime("%Y")}
+        solr_doc[year_fld] = [] unless solr_doc.include?(year_fld)
+        solr_doc[year_fld] << years unless years.blank?
+        solr_doc[year_fld].flatten!
         # date as complex_date_type displayable
         fld_name = Solrizer.solr_name("complex_date_#{label}", :displayable)
         solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
@@ -55,19 +66,20 @@ module ComplexField
     def self.date_facet_fields
       # solr fields that will be treated as facets
       fields = []
-      fields << Solrizer.solr_name('complex_date_accepted', :dateable)
-      fields << Solrizer.solr_name('complex_date_available', :dateable)
-      fields << Solrizer.solr_name('complex_date_copyrighted', :dateable)
-      fields << Solrizer.solr_name('complex_date_collected', :dateable)
-      fields << Solrizer.solr_name('complex_date_created', :dateable)
-      fields << Solrizer.solr_name('complex_date_issued', :dateable)
-      fields << Solrizer.solr_name('complex_date_published', :dateable)
-      fields << Solrizer.solr_name('complex_date_submitted', :dateable)
-      fields << Solrizer.solr_name('complex_date_updated', :dateable)
-      fields << Solrizer.solr_name('complex_date_valid', :dateable)
-      fields << Solrizer.solr_name('complex_date_processed', :dateable)
-      fields << Solrizer.solr_name('complex_date_purchased', :dateable)
-      fields << Solrizer.solr_name('complex_date_other', :dateable)
+      # change all dates to years
+      fields << Solrizer.solr_name('complex_year_accepted', :facetable)
+      fields << Solrizer.solr_name('complex_year_available', :facetable)
+      fields << Solrizer.solr_name('complex_year_copyrighted', :facetable)
+      fields << Solrizer.solr_name('complex_year_collected', :facetable)
+      fields << Solrizer.solr_name('complex_year_created', :facetable)
+      fields << Solrizer.solr_name('complex_year_issued', :facetable)
+      fields << Solrizer.solr_name('complex_year_published', :facetable)
+      fields << Solrizer.solr_name('complex_year_submitted', :facetable)
+      fields << Solrizer.solr_name('complex_year_updated', :facetable)
+      fields << Solrizer.solr_name('complex_year_valid', :facetable)
+      fields << Solrizer.solr_name('complex_year_processed', :facetable)
+      fields << Solrizer.solr_name('complex_year_purchased', :facetable)
+      fields << Solrizer.solr_name('complex_year_other', :facetable)
       fields
     end
 
@@ -75,6 +87,7 @@ module ComplexField
       # solr fields that will be used for a search
       fields = []
       fields << Solrizer.solr_name('complex_date', :stored_searchable, type: :date)
+      fields << Solrizer.solr_name('complex_year', :stored_searchable)
       fields
     end
 

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -9,18 +9,31 @@ en:
           characterization_methods_sim: Characterization methods
           complex_date_dtsim: Date
           complex_date_accepted_dtsim: Date accepted
+          complex_year_accepted_sim: Date accepted
           complex_date_available_dtsim: Date available
+          complex_year_available_sim: Date available
           complex_date_copyrighted_dtsim: Date copyrighted
+          complex_year_copyrighted_sim: Date copyrighted
           complex_date_collected_dtsim: Date collected
+          complex_year_collected_sim: Date collected
           complex_date_created_dtsim: Date created
+          complex_year_created_sim: Date created
           complex_date_issued_dtsim: Date issued
+          complex_year_issued_sim: Date issued
           complex_date_published_dtsim: Date published
+          complex_year_published_sim: Date published
           complex_date_submitted_dtsim: Date submitted
+          complex_year_submitted_sim: Date submitted
           complex_date_updated_dtsim: Date updated
+          complex_year_updated_sim: Date updated
           complex_date_valid_dtsim: Date valid
+          complex_year_valid_sim: Date valid
           complex_date_processed_dtsim: Date processed
+          complex_year_processed_sim: Date processed
           complex_date_purchased_dtsim: Date purchased
+          complex_year_purchased_sim: Date purchased
           complex_date_other_dtsim: Date
+          complex_year_other_sim: Date
           complex_event_sim: Event
           complex_material_sub_type_sim: Material sub type
           complex_material_type_sim: Material type

--- a/hyrax/spec/indexers/dataset_indexer_spec.rb
+++ b/hyrax/spec/indexers/dataset_indexer_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe DatasetIndexer do
       expect(@solr_document['complex_date_dtsim']).to match_array(
         ["1988-10-28T00:00:00Z", "2018-01-01T00:00:00Z"])
     end
+    it 'indexes year as facetable' do
+      expect(@solr_document['complex_year_sim']).to match_array(
+        ["1988", "2018"])
+    end
     it 'indexes each type as sortable' do
       skip 'this cannot be multi-valued'
       expect(@solr_document['complex_date_submitted_dtsi']).to match_array("1988-10-28T00:00:00Z")
@@ -41,6 +45,9 @@ RSpec.describe DatasetIndexer do
     end
     it 'indexes each type as displayable' do
       expect(@solr_document['complex_date_submitted_ssm']).to match_array(["1988-10-28"])
+    end
+    it 'indexes each year as facetable' do
+      expect(@solr_document['complex_year_submitted_sim']).to match_array(["1988"])
     end
   end
 


### PR DESCRIPTION
This PR:

* add facetable _year_ fields for all dates
* switches date facets to use year fields instead of date fields
* adds a complex_year_tesim field for searching on complex_date (I noticed during testing that searching for a year would return no results, this fixes it)
* adds labels (using Date rather than Year)

<img width="1053" alt="Screenshot 2020-02-21 at 17 15 59" src="https://user-images.githubusercontent.com/722117/75056196-6738e700-54ce-11ea-934f-d4b5a00d6968.png">