### PR TITLE
download_all option

### DIFF
--- a/hyrax/.solr_wrapper
+++ b/hyrax/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 7.7.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/hyrax/app/controllers/download_all_controller.rb
+++ b/hyrax/app/controllers/download_all_controller.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+class DownloadAllController < Hyrax::DownloadsController
+  include HyraxHelper
+  include Hydra::Controller::DownloadBehavior
+  include Hyrax::LocalFileDownloadsControllerBehavior
+
+  # GET /download_all/1
+  def show
+    respond_to do |format|
+      format.zip { send_zip }
+      format.any { head :unsupported }
+    end
+  end
+
+  private
+
+  # Override from DownloadsController
+  #
+  # @return [String] path to zip
+  def file
+    @file ||= zip_file
+  end
+
+  # Override from DownloadBehavior
+  def asset
+    @work ||= ActiveFedora::Base.find(params[:id])
+  end
+
+  def send_zip
+    if within_file_size_threshold?(asset.file_set_ids)
+      build_zip
+      # Hyrax::LocalFileDownloadsControllerBehavior#send_local_content
+      send_local_content
+    else
+      head :unsupported
+    end
+  end
+
+  # Extend here to add other files to the zip
+  def build_zip
+    mk_zip_file_path
+    add_metadata
+    add_files
+    zip!
+  end
+
+  # Add :ttl metadata from resource.dump(:ttl) 
+  # Change this method to write a different metadata format
+  def add_metadata
+    File.write(
+      File.join(zip_file_path, 'metadata.ttl'),
+      asset.resource.dump(:ttl),
+      mode: 'wb'
+    )
+  end
+
+  # Add all file_sets
+  def add_files
+    file_sets(asset.file_set_ids).each do |fs|
+      file_set = FileSet.find(fs['id'])
+      next if file_set.blank?
+
+      original = file_set.original_file
+      next if original.blank?
+
+      File.write(
+        File.join(zip_file_path, original.file_name.first),
+        URI.parse(original.uri).open.read,
+        mode: 'wb'
+      )
+    end
+  end
+
+  def mk_zip_file_path
+    FileUtils.mkdir_p(zip_file_path)
+  end
+
+  def zip_file_path
+    @zip_file_path ||= File.join(
+      ENV.fetch('RAILS_TMP', '/tmp'),
+      asset.id.to_s
+    )
+  end
+
+  def zip_file
+    @zip_file ||= "#{zip_file_path}.zip"
+  end
+
+  def zip!
+    WillowSword::ZipPackage.new(
+      zip_file_path, zip_file
+    ).create_zip
+  end
+
+  # Override from LocalFileDownloadsControllerBehavior
+  def local_file_mime_type
+    'application/zip'
+  end
+
+  # Override from LocalFileDownloadsControllerBehavior
+  def local_file_name
+    "#{asset.id}.zip"
+  end
+
+  # Override from LocalFileDownloadsControllerBehavior
+  def local_derivative_download_options
+    super.merge(disposition: 'attachment')
+  end
+end

--- a/hyrax/app/controllers/download_all_controller.rb
+++ b/hyrax/app/controllers/download_all_controller.rb
@@ -115,7 +115,7 @@ class DownloadAllController < Hyrax::DownloadsController
   end
 
   def file_name
-    current_user.present? ? "#{asset.id}_user#{current_user.id}" : asset.id.to_s
+    current_user.present? ? "#{asset.id}_user#{current_user.user_identifier.to_s}" : asset.id.to_s
   end
 
   # Override from LocalFileDownloadsControllerBehavior

--- a/hyrax/app/helpers/hyrax_helper.rb
+++ b/hyrax/app/helpers/hyrax_helper.rb
@@ -40,7 +40,7 @@ module HyraxHelper
   end
 
   def total_size_file_sets(ids)
-    @total_size_file_sets ||= file_sets(ids).map { |fs| fs['file_size_lts'] }.inject(:+) || 0
+    @total_size_file_sets ||= file_sets(ids).map { |fs| fs['file_size_lts'] }.compact.inject(:+) || 0
   end
 
   def file_sets(ids)

--- a/hyrax/app/helpers/hyrax_helper.rb
+++ b/hyrax/app/helpers/hyrax_helper.rb
@@ -27,4 +27,29 @@ module HyraxHelper
     text = user.respond_to?(:name) ? user.name : user_or_key
     link_to text, Hyrax::Engine.routes.url_helpers.user_path(user.user_identifier)
   end
+  
+  # Gather file_sets ids available to the requesting user
+  def available_file_set_ids(presenter, ability)
+    presenter.file_set_presenters.select do |p|
+      ability.can?(:read, p.id)
+    end.collect(&:id)
+  end
+
+  def within_file_size_threshold?(ids)
+    total_size_file_sets(ids) > 0 && total_size_file_sets(ids) < max_size_file_sets
+  end
+
+  def total_size_file_sets(ids)
+    @total_size_file_sets ||= file_sets(ids).map { |fs| fs['file_size_lts'] }.inject(:+) || 0
+  end
+
+  def file_sets(ids)
+    @file_sets ||= FileSet.search_with_conditions(id: ids)
+  end
+
+  # 100Mb
+  def max_size_file_sets
+    100_000_000
+  end
+
 end

--- a/hyrax/app/views/hyrax/base/_download_all.html.erb
+++ b/hyrax/app/views/hyrax/base/_download_all.html.erb
@@ -1,7 +1,7 @@
 
-<%# Only show the download all button if there are file_sets, and the total size is > 0 and < 100Mb %>
-<% if presenter.member_presenters.length > 1 %>
-<% file_set_ids = presenter.member_presenters.map {|fs| fs.id }.compact %>
+<%# Only show the download all button if there are available file_sets, and the total size is > 0 and < 100Mb %>
+<% file_set_ids = available_file_set_ids(presenter, current_ability)%>
+<% if presenter.member_presenters.length > 0 && file_set_ids.size > 0 %>
   <% if within_file_size_threshold?(file_set_ids) %>
     <div class="download-all">
       <%= link_to t(:'hyrax.download_all'),

--- a/hyrax/app/views/hyrax/base/_download_all.html.erb
+++ b/hyrax/app/views/hyrax/base/_download_all.html.erb
@@ -1,0 +1,15 @@
+
+<%# Only show the download all button if there are file_sets, and the total size is > 0 and < 100Mb %>
+<% if presenter.member_presenters.length > 1 %>
+<% file_set_ids = presenter.member_presenters.map {|fs| fs.id }.compact %>
+  <% if within_file_size_threshold?(file_set_ids) %>
+    <div class="download-all">
+      <%= link_to t(:'hyrax.download_all'),
+        main_app.download_all_path(presenter.id, format: :zip),
+        id: "download-all",
+        class: "btn btn-default",
+        target: "_new"
+        %>
+    </div>
+  <% end %>
+<% end %>

--- a/hyrax/app/views/hyrax/base/_representative_media.html.erb
+++ b/hyrax/app/views/hyrax/base/_representative_media.html.erb
@@ -8,3 +8,5 @@
 <% else %>
   <%= image_tag 'default.png', class: "canonical-image" %>
 <% end %>
+
+<%= render 'download_all', presenter: @presenter %>

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -236,6 +236,7 @@ en:
     account_name: My Institution Account Id
     directory:
       suffix: "@example.org"
+    download_all: Download All Files (Zip)
     footer:
       copyright_html: "Copyright &copy; National Institute for Materials Science"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.

--- a/hyrax/config/routes.rb
+++ b/hyrax/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :download_all, only: :show
+
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
 

--- a/hyrax/spec/controllers/download_all_controller_spec.rb
+++ b/hyrax/spec/controllers/download_all_controller_spec.rb
@@ -6,16 +6,13 @@ RSpec.describe DownloadAllController, type: :controller do
   routes { Rails.application.routes }
 
   describe 'GET #show' do
-    let(:user) { create(:user) } # not used yet!
     let(:file_set) { create(:file_set) }
     let(:dataset) { create(:dataset, members: [file_set]) }
 
-    before do
-      allow(subject).to receive(:authorize_download!).and_return(true)
-    end
-
-    context 'with file_sets' do
+    context 'with public file_set' do
       before do
+        allow(subject).to receive(:authorize_download!).and_return(true)
+        allow(subject).to receive(:available_file_set_ids).and_return([file_set.id])
         CharacterizeJob.perform_now(file_set, file_set.original_file.id)
       end
 
@@ -23,7 +20,6 @@ RSpec.describe DownloadAllController, type: :controller do
         it 'returns a success response' do
           get :show, params: { id: dataset.id, format: :zip }
           expect(response).to be_successful
-          expect(File.exist?('/tmp/test-0151_Dataset.zip')).to be_truthy
         end
       end
 
@@ -38,7 +34,23 @@ RSpec.describe DownloadAllController, type: :controller do
     context 'without file_sets' do
       let(:dataset) { create(:dataset) }
 
+      before do
+        allow(subject).to receive(:available_file_set_ids).and_return([])
+      end
+
       context 'request application/zip but without filesets' do
+        it 'returns a failed response' do
+          get :show, params: { id: dataset.id, format: :zip }
+          expect(response).not_to be_successful
+        end
+      end
+    end
+
+    context 'with restricted file_sets' do
+      let(:file_set) { create(:file_set, :restricted) }
+      let(:dataset) { create(:dataset, members: [file_set]) }
+
+      context 'request application/zip' do
         it 'returns a failed response' do
           get :show, params: { id: dataset.id, format: :zip }
           expect(response).not_to be_successful

--- a/hyrax/spec/controllers/download_all_controller_spec.rb
+++ b/hyrax/spec/controllers/download_all_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'devise'
+
+RSpec.describe DownloadAllController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  routes { Rails.application.routes }
+
+  describe 'GET #show' do
+    let(:user) { create(:user) } # not used yet!
+    let(:file_set) { create(:file_set) }
+    let(:dataset) { create(:dataset, members: [file_set]) }
+
+    before do
+      allow(subject).to receive(:authorize_download!).and_return(true)
+    end
+
+    context 'with file_sets' do
+      before do
+        CharacterizeJob.perform_now(file_set, file_set.original_file.id)
+      end
+
+      context 'request application/zip' do
+        it 'returns a success response' do
+          get :show, params: { id: dataset.id, format: :zip }
+          expect(response).to be_successful
+          expect(File.exist?('/tmp/test-0151_Dataset.zip')).to be_truthy
+        end
+      end
+
+      context 'request anything other than application/zip' do
+        it 'returns a failed response' do
+          get :show, params: { id: dataset.id, format: :html }
+          expect(response).not_to be_successful
+        end
+      end
+    end
+
+    context 'without file_sets' do
+      let(:dataset) { create(:dataset) }
+
+      context 'request application/zip but without filesets' do
+        it 'returns a failed response' do
+          get :show, params: { id: dataset.id, format: :zip }
+          expect(response).not_to be_successful
+        end
+      end
+    end
+  end
+end

--- a/hyrax/spec/factories/file_sets.rb
+++ b/hyrax/spec/factories/file_sets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :file_set do
     transient do
       user { create(:user) }
-      content { nil }
+      content { File.open('spec/fixtures/csv/example.csv', 'r') }
     end
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
@@ -34,7 +34,7 @@ FactoryBot.define do
 
     trait :restricted do
       visibility { 'restricted' }
-      title { ["Resstricted File Set"] }
+      title { ["Restricted File Set"] }
     end
   end
 end

--- a/hyrax/spec/helpers/hyrax_helper_spec.rb
+++ b/hyrax/spec/helpers/hyrax_helper_spec.rb
@@ -1,13 +1,64 @@
 require 'rails_helper'
 
-RSpec.describe HyraxHelper, :type => :helper do
+RSpec.describe HyraxHelper, type: :helper do
   describe '#available_translations' do
     it 'returns available translations' do
-      expect(helper.available_translations).to eql({"en"=>"English"})
+      expect(helper.available_translations).to eql('en' => 'English')
     end
   end
 
-  it 'has no singleton methods' do
-    expect(subject.singleton_methods).to be_empty
+  describe '#available_file_set_ids' do
+    let(:file_set) { create(:file_set) }
+    let(:dataset) { create(:dataset, members: [file_set]) }
+    let(:solr_document) { SolrDocument.new(dataset.to_solr) }
+    let(:ability) { Ability.new(create(:user)) }
+    let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability) }
+
+    before do
+      allow(presenter).to receive(:file_set_presenters).and_return([file_set])
+    end
+
+    context 'user can read file_set' do
+      before do
+        allow(ability).to receive(:can?).and_return(true)
+      end
+      it 'returns available_file_set_ids' do
+        expect(helper.available_file_set_ids(presenter, ability)).to eq([file_set.id])
+      end
+    end
+
+    context 'user cannot read file_set' do
+      before do
+        allow(ability).to receive(:can?).and_return(false)
+      end
+
+      it 'returns available_file_set_ids' do
+        expect(helper.available_file_set_ids(presenter, ability)).to eq([])
+      end
+    end
+  end
+
+  describe '#within_file_size_threshold?' do
+    let(:file_set) { create(:file_set) }
+
+    before do
+      CharacterizeJob.perform_now(file_set, file_set.original_file.id)
+    end
+
+    context 'above threshold' do
+      before do
+        allow(helper).to receive(:total_size_file_sets).with([file_set.id]).and_return(100_000_001)
+      end
+
+      it 'returns true' do
+        expect(helper.within_file_size_threshold?([file_set.id])).to eq(false)
+      end
+    end
+
+    context 'below threshold' do
+      it 'returns true' do
+        expect(helper.within_file_size_threshold?([file_set.id])).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR:

* adds a download all route and controller
* adds a button to the show page, but only when the total size of file_sets for the work does not exceed 100Mb
* downloads the files, plus the :ttl format of the metadata to a zip
* downloads only files that the downloading user has access to (ie. excludes private files etc.)

<img width="1152" alt="Screenshot 2020-03-26 at 11 05 15" src="https://user-images.githubusercontent.com/722117/77640174-d6807b80-6f51-11ea-9e4b-20a3fb982c7d.png">