### PR TITLE
Add user_identifier to admin_hyrax user

### DIFF
--- a/hyrax/lib/tasks/setup_hyrax.rake
+++ b/hyrax/lib/tasks/setup_hyrax.rake
@@ -22,7 +22,7 @@ namespace :ngdr do
     admin = Role.where(name: "admin").first_or_create!
     seed["users"].each do |user|
       newUser = User.where(username: user["username"]).first_or_create!(password: user["password"], display_name: user["name"], email: user["email"])
-
+      newuser.user_identifier = 'user_identifier'
       if user["role"] == "admin"
         unless admin.users.include?(newUser)
           admin.users << newUser


### PR DESCRIPTION
With the addition of the `user_identifier` field, if using the development user created by the setup rake task, creating a new work will throw an error. This PR adds a user_identifier to the admin_hyrax user.