### PR TITLE
fix turbolinks vs csv table double render issue

### DIFF
--- a/hyrax/app/assets/javascripts/application.js
+++ b/hyrax/app/assets/javascripts/application.js
@@ -17,10 +17,10 @@
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require bootstrap-datepicker
-//= require csv_preview
 //
 // Required by Blacklight
 //= require blacklight/blacklight
+//= require csv_preview
 
 //= require_tree .
 //= require hyrax

--- a/hyrax/app/assets/javascripts/csv_preview.js
+++ b/hyrax/app/assets/javascripts/csv_preview.js
@@ -1,6 +1,9 @@
-$( document ).on('turbolinks:load', function() {
+Blacklight.onLoad(function() {
     $('.csv-preview').each(function() {
         var preview = $(this);
+        if(preview.hasClass('done')) {
+            return true
+        }
         $.ajax({
             url: preview.data('url'),
             success: function (data) {
@@ -22,6 +25,7 @@ $( document ).on('turbolinks:load', function() {
                 } else {
                     preview.find('.csv-preview-size').hide();
                 }
+                preview.addClass('done')
             },
             error: function() {
                 preview.find('.csv-preview-error').show();


### PR DESCRIPTION
We keep track of which csv tables have been dealt with and then do not ever do them again. This works cleanly because the "done" class is removed whenever turbolinks is cleared (for example on a page refresh)