### PR TITLE
Set newly created nims_mediated_deposit_workflow as default

### DIFF
--- a/hyrax/config/initializers/hyrax.rb
+++ b/hyrax/config/initializers/hyrax.rb
@@ -17,7 +17,7 @@ Hyrax.config do |config|
   # When an admin set is created, we need to activate a workflow.
   # The :default_active_workflow_name is the name of the workflow we will activate.
   # @see Hyrax::Configuration for additional details and defaults.
-  # config.default_active_workflow_name = 'default'
+  config.default_active_workflow_name = 'nims_mediated_deposit'
 
   # Which RDF term should be used to relate objects to an admin set?
   # If this is a new repository, you may want to set a custom predicate term here to

--- a/hyrax/config/workflows/nims_mediated_deposit_workflow.json
+++ b/hyrax/config/workflows/nims_mediated_deposit_workflow.json
@@ -1,0 +1,76 @@
+{
+    "workflows": [
+        {
+            "name": "nims_mediated_deposit",
+            "label": "NIMS mediated deposit workflow",
+            "description": "A workflow for mediated deposit. Works can be created in a draft state, and draft works will not appear in the approval queue. Once out of draft, all deposits must be approved by a reviewer. Reviewer may also send deposits back to the depositor.",
+            "allows_access_grant": false,
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::GrantReadToDepositor",
+                        "Hyrax::Workflow::DeactivateObject"
+                    ]
+                }, {
+                    "name": "request_changes",
+                    "from_states": [{"names": ["deposited", "pending_review"], "roles": ["approving"]}],
+                    "transition_to": "changes_required",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::ChangesRequiredNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::DeactivateObject",
+                        "Hyrax::Workflow::GrantEditToDepositor"
+                    ]
+                }, {
+                    "name": "approve",
+                    "from_states": [{"names": ["pending_review"], "roles": ["approving"]}],
+                    "transition_to": "deposited",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DepositedNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                        "Hyrax::Workflow::GrantReadToDepositor",
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
+                    "name": "request_review",
+                    "from_states": [{"names": ["changes_required"], "roles": ["depositing"]}],
+                    "transition_to": "pending_review",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::PendingReviewNotification",
+                            "to": ["approving"]
+                        }
+                    ]
+                }, {
+                    "name": "comment_only",
+                    "from_states": [
+                        { "names": ["pending_review", "deposited"], "roles": ["approving"] },
+                        { "names": ["changes_required"], "roles": ["depositing"] }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/hyrax/spec/requests/default_workflow_spec.rb
+++ b/hyrax/spec/requests/default_workflow_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Default workflow', type: :request do
+
+  context 'a newly created admin set' do
+    let(:admin) { FactoryBot.create(:user, :admin) }
+
+    it "gets a NIMS workflow" do
+      a = AdminSet.new
+      a.title = ["Fake Admin Set"]
+      a.save
+      Hyrax::AdminSetCreateService.call(admin_set: a, creating_user: admin)
+      expect(a.active_workflow.name).to eq "nims_mediated_deposit"
+    end
+  end
+end


### PR DESCRIPTION
Newly created admin sets should get the nims_mediated_deposit_workflow
as their default workflow.