### PR TITLE
Delete references to deleted forms in contact.feature scenario names

### DIFF
--- a/hyrax/features/contact/contact.feature
+++ b/hyrax/features/contact/contact.feature
@@ -3,21 +3,21 @@ Feature: Contact form
   Background:
     Given an initialised system with a default admin set, permission template and workflow
 
-  Scenario: Unauthenticated user can edit name and email in the contact form
+  Scenario: Unauthenticated user can access the contact form
     When I navigate to the contact form
     Then I should see the contact form
 
-  Scenario: nims_other user cannot edit name and email in the contact form
+  Scenario: nims_other user can access the contact form
     Given I am logged in as a nims_other user
     When I navigate to the contact form
     Then I should see the contact form
 
-  Scenario: nims_researcher user cannot edit name and email in the contact form
+  Scenario: nims_researcher user can access the contact form
     Given I am logged in as a nims_researcher user
     When I navigate to the contact form
     Then I should see the contact form
 
-  Scenario: Admin user cannot edit name and email in the contact form
+  Scenario: Admin user can access the contact form
     Given I am logged in as an admin user
     When I navigate to the contact form
     Then I should see the contact form


### PR DESCRIPTION
After https://github.com/antleaf/nims-hyrax/pull/295 the scenario names pointed to forms that no longer exist.