### PR TITLE
Add draft workflow to Publication work types

### DIFF
--- a/hyrax/app/controllers/hyrax/publications_controller.rb
+++ b/hyrax/app/controllers/hyrax/publications_controller.rb
@@ -15,12 +15,18 @@ module Hyrax
     def create
       safe_params = params['publication'].permit(::Hyrax::PublicationForm.build_permitted_params)
       params['publication'] = cleanup_params(safe_params.to_h)
+      params['publication']['draft'] = ['true'] if params["save_draft_with_files"] == "Save Draft"
       super
     end
 
     def update
       safe_params = params['publication'].permit(::Hyrax::PublicationForm.build_permitted_params)
       params['publication'] = cleanup_params(safe_params.to_h)
+      if params["save_draft_with_files"] == "Save Draft"
+        params['publication']['draft'] = ['true']
+      else
+        params['publication']['draft'] = ['false']
+      end
       super
     end
 

--- a/hyrax/app/forms/hyrax/publication_form.rb
+++ b/hyrax/app/forms/hyrax/publication_form.rb
@@ -23,7 +23,7 @@ module Hyrax
       :publisher, :resource_type, :complex_date, :manuscript_type,
       :complex_identifier, :complex_source, :complex_version, :complex_relation,
       :complex_event, :specimen_set_ordered, :managing_organization_ordered,
-      :language, :licensed_date, :custom_property, :note_to_admin
+      :language, :licensed_date, :custom_property, :note_to_admin, :draft
     ]
 
     self.required_fields -= [

--- a/hyrax/app/indexers/complex_field/relation_indexer.rb
+++ b/hyrax/app/indexers/complex_field/relation_indexer.rb
@@ -10,12 +10,11 @@ module ComplexField
       solr_doc[Solrizer.solr_name('complex_relation', :displayable)] = object.complex_relation.to_json
       solr_doc[Solrizer.solr_name('complex_relation_title', :stored_searchable)] = object.complex_relation.map { |r| r.title.reject(&:blank?).first }
       object.complex_relation.each do |r|
-        unless r.title.blank? || r.relationship.blank?
+        unless r.title.blank? || r.relationship.blank? || only_blank_strings?(r.relationship)
           fld_name = Solrizer.solr_name('complex_relation_relationship', :facetable)
           solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
           solr_doc[fld_name] << r.relationship.reject(&:blank?)
           solr_doc[fld_name].flatten!
-
           relationship = r.relationship.reject(&:blank?).first.downcase.tr(' ', '_')
           fld_name = Solrizer.solr_name("complex_relation_#{relationship}", :facetable)
           solr_doc[fld_name] = [] unless solr_doc.include?(fld_name)
@@ -28,6 +27,14 @@ module ComplexField
           solr_doc[fld_name].flatten!
         end
       end
+    end
+
+    ##
+    # If the complex relation is only an array of blank strings, it doesn't need to be indexed
+    # @return [Boolean]
+    def only_blank_strings?(relationship)
+      relationship.delete("")
+      relationship.empty?
     end
   end
 end

--- a/hyrax/features/datasets/create.feature
+++ b/hyrax/features/datasets/create.feature
@@ -26,7 +26,7 @@ Feature: Create a dataset
       | TITLE           | SUPERVISOR   | DATA_ORIGIN | CREATOR   | KEYWORD  |
       | My Test Dataset | Jones, Janet | experiments | Doe, Jane | big data |
     Then I should see a message that my files are being processed
-    And the dataset that is created should be in a draft workflow state
-    And the dataset that is created is editable by the nims_researcher who deposited it
+    And the work that is created should be in a draft workflow state
+    And the work that is created is editable by the nims_researcher who deposited it
     And the dataset can be submitted for approval
     And after it is approved, it is no longer editable by the nims_researcher who deposited it

--- a/hyrax/features/publications/create.feature
+++ b/hyrax/features/publications/create.feature
@@ -1,0 +1,17 @@
+Feature: Create a publication
+
+  Background:
+    Given an initialised system with a default admin set, permission template and workflow
+
+  Scenario: Create a DRAFT publication as a NIMS Researcher user
+    Given I am logged in as a nims_researcher user
+    And I have permission to deposit
+    When I navigate to the new publication page
+    And I create a draft publication with:
+      | TITLE          | SUPERVISOR   | CREATOR   | KEYWORD  | ABSTRACT            |
+      | My Publication | Jones, Janet | Doe, Jane | big data | This is an abstract |
+    Then I should see a message that my files are being processed
+    And the work that is created should be in a draft workflow state
+    And the work that is created is editable by the nims_researcher who deposited it
+    And the publication can be submitted for approval
+    And after it is approved, it is no longer editable by the nims_researcher who deposited it

--- a/hyrax/features/step_definitions/dataset_steps.rb
+++ b/hyrax/features/step_definitions/dataset_steps.rb
@@ -107,18 +107,6 @@ When(/^I create a draft dataset with:$/) do |table|
   expect(page).to have_content(values[:TITLE])
 end
 
-Then("the dataset that is created should be in a draft workflow state") do
-  dataset = Dataset.last
-  workflow_state = dataset.to_sipity_entity.reload.workflow_state_name
-  expect(workflow_state).to eq "draft"
-end
-
-Then("the dataset that is created is editable by the nims_researcher who deposited it") do
-  dataset = Dataset.last
-  nims_researcher = User.find_by(username: dataset.depositor)
-  expect(dataset.edit_users).to include(dataset.depositor)
-end
-
 Then("the dataset can be submitted for approval") do
   dataset = Dataset.last
   visit edit_hyrax_dataset_path(dataset)
@@ -133,24 +121,6 @@ Then("the dataset can be submitted for approval") do
   dataset.reload
   workflow_state = dataset.to_sipity_entity.reload.workflow_state_name
   expect(workflow_state).to eq "pending_review"
-end
-
-Then("after it is approved, it is no longer editable by the nims_researcher who deposited it") do
-  dataset = Dataset.last
-  admin = FactoryBot.create(:user, :admin)
-  workflow = dataset.active_workflow
-  workflow_roles = Sipity::WorkflowRole.where(workflow_id: workflow.id)
-  workflow_roles.each do |workflow_role|
-    workflow.update_responsibilities(role: Sipity::Role.where(id: workflow_role.role_id), agents: admin)
-  end
-  subject = Hyrax::WorkflowActionInfo.new(dataset, admin)
-  sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
-  Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
-  dataset.reload
-  workflow_state = dataset.to_sipity_entity.reload.workflow_state_name
-  expect(workflow_state).to eq "deposited"
-  nims_researcher = User.find_by(username: dataset.depositor)
-  expect(dataset.edit_users).not_to include(dataset.depositor)
 end
 
 Then(/^I should see the (open|authenticated|embargo|lease|restricted) datasets?$/) do |access|

--- a/hyrax/features/step_definitions/draft_workflow_steps.rb
+++ b/hyrax/features/step_definitions/draft_workflow_steps.rb
@@ -1,0 +1,30 @@
+
+Then("the work that is created should be in a draft workflow state") do
+  work = ActiveFedora::Base.last
+  workflow_state = work.to_sipity_entity.reload.workflow_state_name
+  expect(workflow_state).to eq "draft"
+end
+
+Then("the work that is created is editable by the nims_researcher who deposited it") do
+  work = ActiveFedora::Base.last
+  nims_researcher = User.find_by(username: work.depositor)
+  expect(work.edit_users).to include(work.depositor)
+end
+
+Then("after it is approved, it is no longer editable by the nims_researcher who deposited it") do
+  work = ActiveFedora::Base.last
+  admin = FactoryBot.create(:user, :admin)
+  workflow = work.active_workflow
+  workflow_roles = Sipity::WorkflowRole.where(workflow_id: workflow.id)
+  workflow_roles.each do |workflow_role|
+    workflow.update_responsibilities(role: Sipity::Role.where(id: workflow_role.role_id), agents: admin)
+  end
+  subject = Hyrax::WorkflowActionInfo.new(work, admin)
+  sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
+  Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+  work.reload
+  workflow_state = work.to_sipity_entity.reload.workflow_state_name
+  expect(workflow_state).to eq "deposited"
+  nims_researcher = User.find_by(username: work.depositor)
+  expect(work.edit_users).not_to include(work.depositor)
+end

--- a/hyrax/features/step_definitions/publication_steps.rb
+++ b/hyrax/features/step_definitions/publication_steps.rb
@@ -73,6 +73,52 @@ When(/^I create the publication with:$/) do |table|
   expect(page).to have_content(values[:TITLE])
 end
 
+When(/^I create a draft publication with:$/) do |table|
+  values = table.hashes.first # table is a table.hashes.keys # => [:TITLE, :SUPERVISOR, :DATA_ORIGIN, :CREATOR, :KEYWORD]
+
+  expect(page).to have_content /Add New Publication/i
+
+  click_link "Files" # switch tab
+  expect(page).to have_content /Add files/i
+  expect(page).to have_content /Add folder/i
+  within('span#addfiles') do
+    attach_file("files[]", File.join(fixture_path,  'image.jp2'), visible: false)
+    attach_file("files[]", File.join(fixture_path, 'jp2_fits.xml'), visible: false)
+  end
+
+  click_link "Descriptions" # switch tab
+  fill_in('Title', with: values[:TITLE])
+  fill_in('Supervisor approval', with: "approved")
+  find('#publication_resource_type').select('Dissertation')
+  # fill_in('publication[complex_person_attributes][0][name][]', with: values[:CREATOR])
+  fill_in('Keyword', with: values[:KEYWORD])
+  fill_in('Abstract or Summary', with: values[:ABSTRACT])
+  fill_in('Material/Specimen', with: 'Ooblek')
+  fill_in('Date published', with: '31/12/2020')
+  find('#publication_rights_statement').select('MIT License')
+
+  # With selenium and the chrome driver, focus remains on the
+  # select box. Click outside the box so the next line can't find
+  # its element
+  find('body').click
+  choose('publication_visibility_open')
+  expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+  check('agreement')
+
+  click_on('Save Draft')
+
+  expect(page).to have_content(values[:TITLE])
+end
+
+Then("the publication can be submitted for approval") do
+  publication = Publication.last
+  visit edit_hyrax_publication_path(publication)
+  find('#with_files_submit').click
+  publication.reload
+  workflow_state = publication.to_sipity_entity.reload.workflow_state_name
+  expect(workflow_state).to eq "pending_review"
+end
+
 Then(/^I should see the (open|authenticated|embargo|lease|restricted) publications?$/) do |access|
   # first, verify @publications is present and has some data
   expect(@publications[access]).to be_present


### PR DESCRIPTION
Note that this PR also fixes a bug where submitted publications were failing to index when their "relationship" field consists of an array of empty strings. This but was uncovered in the course of writing feature specs for publication work types. 