### PR TITLE
fix assets:compile error in the production environment

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -14,6 +14,9 @@ services:
     ports:
       - 3000:3000
 
+  workers:
+    <<: *app
+
   fluentd:
     build: ./fluentd
     volumes:


### PR DESCRIPTION
After the PR #300 was merged, I got the following error when build an image using ``docker-compose-production.yml``.

```
#20 7.228 yarn run v1.22.4
#20 7.346 $ shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/
#20 8.296 Done in 1.08s.
#20 8.313 Done in 6.77s.
#20 17.51 rake aborted!
#20 17.51 NoMethodError: undefined method `split' for nil:NilClass
#20 17.51 /usr/local/bundle/gems/act-fluent-logger-rails-0.6.1/lib/act-fluent-logger-rails/logger.rb:57:in `parse_url'
#20 17.51 /usr/local/bundle/gems/act-fluent-logger-rails-0.6.1/lib/act-fluent-logger-rails/logger.rb:33:in `new'
#20 17.51 /data/config/environments/production.rb:133:in `block in <top (required)>'
#20 17.51 /usr/local/bundle/gems/railties-5.2.4.4/lib/rails/railtie.rb:216:in `instance_eval'
#20 17.51 /usr/local/bundle/gems/railties-5.2.4.4/lib/rails/railtie.rb:216:in `configure'
#20 17.51 /data/config/environments/production.rb:1:in `<top (required)>'
```

This PR will fix the problem.