### PR TITLE
Documentation tweak and .gitignore settings for .env.template.development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ $RECYCLE.BIN/
 /hyrax/.fedora-test.pid
 /hyrax/.solr-test.pid
 cas/.mvn/jvm.config
+
+# Default HOST_APP_DATA_PATH in .env.template.development
+/data/


### PR DESCRIPTION
1. A new env template was added for development use: https://github.com/antleaf/nims-hyrax/pull/289#discussion_r539718425 . Instructions for this are added to the Readme. Also deleted some outdated paragraphs in the readme.

2. .env.template uses `HOST_APP_DATA_PATH=/srv/ngdr/data/`. In macOS Catalina (10.15) and later, /srv/ is protected and not available to Docker. I personally have been using `HOST_APP_DATA_PATH=/usr/local/var/ngdr/data/`. The new .env.template.development uses `HOST_APP_DATA_PATH=./data/`. If `./data/` is going to be our new default for development, then this should be excluded from the code repo by .gitignore.

Closes https://github.com/antleaf/nims-mdr-development/issues/382