### PR TITLE
Always use text in locale file for visibility badges

### DIFF
--- a/hyrax/app/presenters/hyrax/permission_badge.rb
+++ b/hyrax/app/presenters/hyrax/permission_badge.rb
@@ -1,0 +1,41 @@
+module Hyrax
+  class PermissionBadge
+    include ActionView::Helpers::TagHelper
+
+    VISIBILITY_LABEL_CLASS = {
+      authenticated: "label-info",
+      embargo: "label-warning",
+      lease: "label-warning",
+      open: "label-success",
+      restricted: "label-danger"
+    }.freeze
+
+    # @param visibility [String] the current visibility
+    def initialize(visibility)
+      @visibility = visibility
+    end
+
+    # Draws a span tag with styles for a bootstrap label
+    def render
+      content_tag(:span, text, class: "label #{dom_label_class}")
+    end
+
+    private
+
+      def dom_label_class
+        VISIBILITY_LABEL_CLASS.fetch(@visibility.to_sym)
+      end
+
+      def text
+        if registered?
+          Institution.name
+        else
+          I18n.t("hyrax.visibility.#{@visibility}.text")
+        end
+      end
+
+      def registered?
+        @visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+  end
+end

--- a/hyrax/app/presenters/hyrax/permission_badge.rb
+++ b/hyrax/app/presenters/hyrax/permission_badge.rb
@@ -27,11 +27,8 @@ module Hyrax
       end
 
       def text
-        if registered?
-          Institution.name
-        else
-          I18n.t("hyrax.visibility.#{@visibility}.text")
-        end
+        I18n.t("hyrax.visibility.#{@visibility}.text")
+        # Hyrax default was if registered? Institution.name
       end
 
       def registered?


### PR DESCRIPTION
Hyrax default behavior is to use institution name for authenticated visibility. https://github.com/samvera/hyrax/blob/2.x-stable/app/presenters/hyrax/permission_badge.rb Changing this to always use visibility text in the locale file.

A follow-up to PR https://github.com/antleaf/nims-hyrax/pull/303. Closes antleaf/nims-mdr-development#375.