### PR TITLE
Override work titles

### DIFF
--- a/hyrax/app/presenters/hyrax/dataset_presenter.rb
+++ b/hyrax/app/presenters/hyrax/dataset_presenter.rb
@@ -13,6 +13,10 @@ module Hyrax
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::NimsFileSetPresenter
     prepend ::FilteredGraph
 
+    def page_title
+      "#{title.first} | #{I18n.t('hyrax.product_name')}"
+    end
+
     def manuscript_type
       ManuscriptTypeService.new.find_by_id(solr_document.manuscript_type.first)&.[](:label) if solr_document.manuscript_type.present?
     end

--- a/hyrax/app/presenters/hyrax/dataset_presenter.rb
+++ b/hyrax/app/presenters/hyrax/dataset_presenter.rb
@@ -14,7 +14,7 @@ module Hyrax
     prepend ::FilteredGraph
 
     def page_title
-      "#{title.first} | #{I18n.t('hyrax.product_name')}"
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
     end
 
     def manuscript_type

--- a/hyrax/app/presenters/hyrax/publication_presenter.rb
+++ b/hyrax/app/presenters/hyrax/publication_presenter.rb
@@ -12,7 +12,7 @@ module Hyrax
     prepend ::FilteredGraph
 
     def page_title
-      "#{title.first} | #{I18n.t('hyrax.product_name')}"
+      "#{title.first} // #{I18n.t('hyrax.product_name')}"
     end
 
     def manuscript_type

--- a/hyrax/app/presenters/hyrax/publication_presenter.rb
+++ b/hyrax/app/presenters/hyrax/publication_presenter.rb
@@ -11,6 +11,10 @@ module Hyrax
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::NimsFileSetPresenter
     prepend ::FilteredGraph
 
+    def page_title
+      "#{title.first} | #{I18n.t('hyrax.product_name')}"
+    end
+
     def manuscript_type
       ManuscriptTypeService.new.find_by_id(solr_document.manuscript_type.first)&.[](:label) if solr_document.manuscript_type.present?
     end


### PR DESCRIPTION
Override page titles to so that the it doesn't start with work types. Closes https://github.com/antleaf/nims-mdr-development/issues/408