### PR TITLE
Add hints and placeholders to metadata edit forms

### DIFF
--- a/hyrax/app/inputs/nested_person_input.rb
+++ b/hyrax/app/inputs/nested_person_input.rb
@@ -99,7 +99,7 @@ protected
 
     out << "  <div class='col-md-9'>"
     out << @builder.text_field(field_name,
-        options.merge(value: field_value, name: field_name, id: field_id, required: required, placeholder: "ORCID"))
+        options.merge(value: field_value, name: field_name, id: field_id, required: required, placeholder: "https://orcid.org/0000-0000-0000-0000"))
     out << '  </div>'
     out << '</div>' # row
 
@@ -116,7 +116,7 @@ protected
 
     out << "  <div class='col-md-9'>"
     out << @builder.text_field(field_name,
-        options.merge(value: field_value, name: field_name, id: field_id, required: required, placeholder: "Alphabets"))
+        options.merge(value: field_value, name: field_name, id: field_id, required: required, placeholder: "Alphabets, unabbreviated"))
     out << '  </div>'
     out << '</div>' # row
 

--- a/hyrax/app/views/records/edit_fields/_supervisor_approval.html.erb
+++ b/hyrax/app/views/records/edit_fields/_supervisor_approval.html.erb
@@ -1,5 +1,4 @@
 <%= f.input :supervisor_approval,
   required: f.object.required?(key),
   as: :multi_value,
-  hint: raw("If you entered a DOI above, enter \"approved\". If you entered a non-DOI URL above, fill in the name of your supervisor and the date of their approval. See <a href='https://dice.nims.go.jp/nimsonly/MDR/manual/html/' target='_blank' rel='noopener'>the User's Manual</a> for details."),
   input_html: {class: 'form-control'} %>

--- a/hyrax/config/locales/en.yml
+++ b/hyrax/config/locales/en.yml
@@ -59,7 +59,27 @@ en:
   simple_form:
     hints:
       defaults:
-        title: A name to aid in identifying a work. English is preferred.
+        first_published_url: The DOI (in URL form) of the article related to this dataset or the URL where this dataset was first made public.
+        supervisor_approval: "If you entered a DOI above, enter \"approved\". If you entered a non-DOI URL above, fill in the name of your supervisor and the date of their approval. See <a href='https://dice.nims.go.jp/nimsonly/MDR/manual/html/' target='_blank' rel='noopener'>the User's Manual</a> for details."
+        title: English is preferred.
+        alternative_title: Alternative title or the title in other language, if applicable.
+        rights_statement: 'Copyright and license for your work. If none apply, select "In Copyright".'
+        licensed_date: Date when the work was released under the license selected above.
+        data_origin: Type of research.
+        resource_type: Type of content. More than one type may be selected.
+        description: Abstract or a free-text description for the work.
+        keyword_ordered: '<strong>Note:</strong> To enter multiple keywords, click on "Add another Keyword." Do not list them in a single field.'
         publisher: The person or group making the work available.
-        first_published_url: "The DOI of the article related to this dataset or the URL where this dataset was first made public. DOI example: https://doi.org/10.xxxx/xxxxx"
+        specimen_set_ordered: Short description of the material/specimen studied in this work.
+        managing_organization_ordered: Organization in charge of this work. Usually this is your affiliation. May be abbreviated.
         complex_person: '<span class="label label-info required-tag">required</span> Authors or contributors to the work. Enter the Surname, the Given name, and the full name again in "Name", and select their Role.'
+        manuscript_type: Version of the manuscript, if you are uploading a journal article.
+        complex_identifier: External identifiers, if applicable.
+        complex_source: '<span class="label label-info required-tag">required for journal articles</span>'
+        complex_event: '<span class="label label-info required-tag">required for conference presentations</span>'
+        custom_property: You may add custom properties not covered by the fields above.
+        note_to_admin: Text written here will not be publicly visible.
+    placeholders:
+      defaults:
+        first_published_url: "https://doi.org/10.xxx/xxxx"
+        managing_organization_ordered: NIMS

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -110,7 +110,7 @@ en:
           complex_material_type_description_tesim: Material type description
           complex_material_type_identifier_ssim: Material identifier
           complex_identifier_ssim: Identifier
-          complex_identifier_orcid_ssim: Orcid
+          complex_identifier_orcid_ssim: ORCID
           complex_identifier_local_id_ssim: Local identifier
           complex_person_other_tesim: Creator
           complex_person_author_tesim: Author

--- a/hyrax/spec/factories/publication.rb
+++ b/hyrax/spec/factories/publication.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
         [{
           name: ['Foo Bar'],
           role: ['author'],
-          orcid: ['https://orcid.example.org/0000-1111-2222-3333'],
+          orcid: ['https://orcid.org/0000-0002-1825-0097'],
           organization: ['National Institute for Materials Science'],
           sub_organization: ['MaDIS DPFC'],
           complex_identifier_attributes: [{

--- a/hyrax/spec/views/hyrax/publications/_attribute_rows.html_spec.rb
+++ b/hyrax/spec/views/hyrax/publications/_attribute_rows.html_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'hyrax/publications/_attribute_rows' do
       expect(rendered).to have_content('2019-05-28')
       expect(rendered).to have_content('10.0.1111')
       expect(rendered).to have_content('Foo Bar')
-      expect(rendered).to have_content('https://orcid.example.org/0000-1111-2222-3333')
+      expect(rendered).to have_content('https://orcid.org/0000-0002-1825-0097')
       expect(rendered).to have_content('MaDIS DPFC')
       expect(rendered).to have_content('Creating the first version')
       expect(rendered).to have_content('Event-Title-123')


### PR DESCRIPTION
Adds much-needed hints and placeholders to aid users' inputs. The ORCID in the spec is for a fictitious Prof. Josiah Carberry. Closes https://github.com/antleaf/nims-mdr-development/issues/409