### PR TITLE
Delete warning before the save button

### DIFF
--- a/hyrax/app/views/hyrax/base/_form_progress.html.erb
+++ b/hyrax/app/views/hyrax/base/_form_progress.html.erb
@@ -26,6 +26,10 @@
           <%= f.input :on_behalf_of, collection: current_user.can_make_deposits_for.map(&:user_key), prompt: "Yourself" %>
         </div>
     <% end %>
+
+    <% form_progress_sections_for(form: f.object).each do |section| %>
+      <%= render "form_progress_#{section}", f: f %>
+    <% end %>
   </div>
   <div class="panel-footer label-warning">
     <strong>&#x26a0; Your data will not be made public yet! After you push the button, send the URL of the next screen to <a href="mailto:<%= ENV['CONTACT_EMAIL']%>"><%= ENV['CONTACT_EMAIL'] %></a>.</strong>

--- a/hyrax/app/views/hyrax/base/_form_progress.html.erb
+++ b/hyrax/app/views/hyrax/base/_form_progress.html.erb
@@ -31,9 +31,6 @@
       <%= render "form_progress_#{section}", f: f %>
     <% end %>
   </div>
-  <div class="panel-footer label-warning">
-    <strong>&#x26a0; Your data will not be made public yet! After you push the button, send the URL of the next screen to <a href="mailto:<%= ENV['CONTACT_EMAIL']%>"><%= ENV['CONTACT_EMAIL'] %></a>.</strong>
-  </div>
   <div class="panel-footer text-center">
     <% if ::Flipflop.show_deposit_agreement? %>
       <% if ::Flipflop.active_deposit_agreement_acceptance? %>


### PR DESCRIPTION
- Deletes the warning notice added in https://github.com/antleaf/nims-hyrax/pull/203 before the save button to align with the new workflow. 
- Adds code that was added in upstream (https://github.com/samvera/hyrax/commit/ccfa31cb08f2cb914d26f38a2b177cd97cd63bb8) after _form_progress.html.erb was forked for #203. This would make the only difference between nims-hyrax and upstream the existence of the draft button.

```diff
diff hyrax/app/views/hyrax/base/_form_progress.html.erb nims-hyrax/hyrax/app/views/hyrax/base/_form_progress.html.erb
55c55,56
<     <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
---
>     <%= f.submit t('.save_draft'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit_draft", name: "save_draft_with_files" %>
>     <%= f.submit t('.save'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
```

Closes https://github.com/antleaf/nims-mdr-development/issues/410