### PR TITLE
add default port number to IIIF URLs

### DIFF
--- a/hyrax/config/initializers/hyrax.rb
+++ b/hyrax/config/initializers/hyrax.rb
@@ -152,14 +152,21 @@ Hyrax.config do |config|
   else
     protocol = 'http'
   end
+
+  if Rails.env.development?
+    port = ENV.fetch('PORT', 3000)
+  else
+    port = nil
+  end
+
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size, protocol: protocol, port: ENV.fetch('PORT', 3000))
+    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size, protocol: protocol, port: port)
   end
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url, protocol: protocol, port: ENV.fetch('PORT', 3000))
+    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url, protocol: protocol, port: port)
     uri.sub(%r{/info\.json\Z}, '')
   end
 

--- a/hyrax/config/initializers/hyrax.rb
+++ b/hyrax/config/initializers/hyrax.rb
@@ -154,12 +154,12 @@ Hyrax.config do |config|
   end
   # Returns a URL that resolves to an image provided by a IIIF image server
   config.iiif_image_url_builder = lambda do |file_id, base_url, size|
-    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size, protocol: protocol)
+    Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size, protocol: protocol, port: ENV.fetch('PORT', 3000))
   end
 
   # Returns a URL that resolves to an info.json file provided by a IIIF image server
   config.iiif_info_url_builder = lambda do |file_id, base_url|
-    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url, protocol: protocol)
+    uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url, protocol: protocol, port: ENV.fetch('PORT', 3000))
     uri.sub(%r{/info\.json\Z}, '')
   end
 


### PR DESCRIPTION
This PR will fix https://github.com/antleaf/nims-mdr-development/issues/395 .

Please note you would still need to run ``yarn install`` manually.