### PR TITLE
Add no-edits-after-deposit notice

### DIFF
--- a/hyrax/app/views/hyrax/base/_form_progress.html.erb
+++ b/hyrax/app/views/hyrax/base/_form_progress.html.erb
@@ -27,6 +27,9 @@
         </div>
     <% end %>
 
+    <% form_progress_sections_for(form: f.object).each do |section| %>
+      <%= render "form_progress_#{section}", f: f %>
+    <% end %>
   </div>
   <div class="panel-footer text-center">
     <% if ::Flipflop.show_deposit_agreement? %>

--- a/hyrax/app/views/hyrax/base/_form_progress.html.erb
+++ b/hyrax/app/views/hyrax/base/_form_progress.html.erb
@@ -27,9 +27,6 @@
         </div>
     <% end %>
 
-    <% form_progress_sections_for(form: f.object).each do |section| %>
-      <%= render "form_progress_#{section}", f: f %>
-    <% end %>
   </div>
   <div class="panel-footer text-center">
     <% if ::Flipflop.show_deposit_agreement? %>
@@ -54,6 +51,9 @@
     <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
     <%= f.submit t('.save_draft'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit_draft", name: "save_draft_with_files" %>
     <%= f.submit t('.save'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+  </div>
+  <div class="panel-footer text-muted">
+    <p><%= t('hyrax.works.form.submit_caution_html') %></p>
   </div>
 
   <%# Provide immediate feedback after the form is submitted while the subsequent page is loading %>

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -273,6 +273,7 @@ en:
     product_twitter_handle: "@nims_library"
     works:
       form:
+        submit_caution_html: <strong>Note:</strong> After your work has been submitted and successfully deposited, you will not be able to edit it.
         tab:
           files: Files
           metadata: Descriptions


### PR DESCRIPTION
Adds a little notice before submission warning users that they will lose the ability to edit the work upon successful deposit.

NIMS issue 513