### PR TITLE
Add contact person role in catalog view

### DIFF
--- a/hyrax/app/controllers/catalog_controller.rb
+++ b/hyrax/app/controllers/catalog_controller.rb
@@ -82,6 +82,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('complex_person_data_depositor', :stored_searchable), itemprop: 'data depositor', link_to_search: solr_name('complex_person_data_depositor', :facetable)
     config.add_index_field solr_name('complex_person_data_curator', :stored_searchable), itemprop: 'data curator', link_to_search: solr_name('complex_person_data_curator', :facetable)
     config.add_index_field solr_name('complex_person_operator', :stored_searchable), itemprop: 'operator', link_to_search: solr_name('complex_person_operator', :facetable)
+    config.add_index_field solr_name('complex_person_contact_person', :stored_searchable), itemprop: 'contact person', link_to_search: solr_name('complex_person_contact_person', :facetable)
     config.add_index_field solr_name('complex_person_other', :stored_searchable), itemprop: 'creator or contributor', link_to_search: solr_name('complex_person_other', :facetable)
     # config.add_index_field solr_name('proxy_depositor', :symbol), label: 'Depositor', helper_method: :link_to_profile
     #  config.add_index_field solr_name('depositor'), label: 'Owner', helper_method: :link_to_profile

--- a/hyrax/app/indexers/complex_field/person_indexer.rb
+++ b/hyrax/app/indexers/complex_field/person_indexer.rb
@@ -78,6 +78,7 @@ module ComplexField
       fields << Solrizer.solr_name('complex_person_data_depositor', :facetable)
       fields << Solrizer.solr_name('complex_person_data_curator', :facetable)
       fields << Solrizer.solr_name('complex_person_operator', :facetable)
+      fields << Solrizer.solr_name('complex_person_contact_person', :facetable)
       fields << Solrizer.solr_name('complex_person_organization', :facetable)
       fields << Solrizer.solr_name('complex_person_sub_organization', :facetable)
       fields

--- a/hyrax/config/locales/hyrax.en.yml
+++ b/hyrax/config/locales/hyrax.en.yml
@@ -119,6 +119,7 @@ en:
           complex_person_data_depositor_tesim: Data depositor
           complex_person_data_curator_tesim: Data curator
           complex_person_operator_tesim: Operator
+          complex_person_contact_person_tesim: Contact person
           complex_person_organization_tesim: Organization
           complex_person_sub_organization_tesim: Sub organization
           complex_purchase_record_item_tesim: Purchase record item
@@ -200,6 +201,7 @@ en:
           complex_person_data_depositor_ssm: Data depositor
           complex_person_data_curator_ssm: Data curator
           complex_person_operator_ssm: Operator
+          complex_person_contact_person_ssm: Contact person
           complex_person_organization_ssm: Organization
           complex_person_sub_organization_ssm: Sub organization
           complex_relation_ssm: Related item


### PR DESCRIPTION
Adds contact person (added back in https://github.com/antleaf/nims-hyrax/pull/355) to catalog view. This role was (afaik) missing from catalog view even before removal of the role.

Closes https://github.com/antleaf/nims-mdr-development/issues/433